### PR TITLE
マイページに本人以外がアクセスできない様にコード修正#19

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:show]
   
   def show
-    unless current_user.id == params[:id]
+    unless current_user.id == params[:id].to_i
       redirect_to root_path
     else
       @user = User.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,11 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:show]
-
+  
   def show
-    @user = User.find(params[:id])
+    unless current_user.id == params[:id]
+      redirect_to root_path
+    else
+      @user = User.find(params[:id])
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:show]
+
   def show
     @user = User.find(params[:id])
   end


### PR DESCRIPTION
## 概要
* 未ログインユーザーや他人のユーザーでも自身のマイページにアクセスできてしまっているので、本人だけがアクセスできる様にしたい。

## 変更点
* usersコントローラーに'before_action'で'authenticate_user!'を設定して、未ログインユーザーはログイン画面へ遷移される様に変更。
* usersコントローラー内のshowアクション内にて'current_user.id'と'params[:id]'が合致するかどうかを判定し、違っていれば、トップページへリダイレクトされる様にコードを修正。

## テスト結果とテスト項目
- [x] 未ログインユーザーがマイページへアクセスすると、ログイン画面へリダイレクトされる。
- [x] ログインユーザーが他人のマイページへアクセスすると、トップページへリダイレクトされる。

## Issue番号
close #19 