### PR TITLE
会員登録しなくても、テストユーザーとしてログインできる機能実装

### DIFF
--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -90,26 +90,6 @@ $regHeight: 881px;
                 }
               }
             }
-            .testUserSignInForm{
-              width: 100%;
-              margin-top: 10px;
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              .testUserLoginText{
-                font-size: 14px;
-                margin-right: 5px;
-              }
-              .testUserLoginForm{
-                .tesuUserLoginButton{
-                  font-size: 14px;
-                  color: #008dde;
-                  border-style: none;
-                  background-color: #fff;
-                  cursor: pointer;
-                }
-              }
-            }
             .socialLogin{
               border-top: 1px solid #ccc;
               margin-top: 30px;
@@ -153,6 +133,26 @@ $regHeight: 881px;
               .registerPolicyLink{
                 color: #008dde!important;
                 text-decoration: none!important;
+              }
+            }
+            .testUserSignInForm{
+              width: 100%;
+              margin-top: 20px;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              .testUserLoginText{
+                font-size: 14px;
+                margin-right: 5px;
+              }
+              .testUserLoginForm{
+                .tesuUserLoginButton{
+                  font-size: 14px;
+                  color: #008dde;
+                  border-style: none;
+                  background-color: #fff;
+                  cursor: pointer;
+                }
               }
             }
             .loginLink{

--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -90,6 +90,26 @@ $regHeight: 881px;
                 }
               }
             }
+            .testUserSignInForm{
+              width: 100%;
+              margin-top: 10px;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              .testUserLoginText{
+                font-size: 14px;
+                margin-right: 5px;
+              }
+              .testUserLoginForm{
+                .tesuUserLoginButton{
+                  font-size: 14px;
+                  color: #008dde;
+                  border-style: none;
+                  background-color: #fff;
+                  cursor: pointer;
+                }
+              }
+            }
             .socialLogin{
               border-top: 1px solid #ccc;
               margin-top: 30px;

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -35,6 +35,12 @@
                 %div
                   %a{href: '#', class: 'socialLoginLink'}
               = render "devise/shared/links"
+              .testUserSignInForm
+                %span.testUserLoginText ※アカウント登録せず、ユーザー機能を試したい方は
+                = form_with model: @user, url: user_session_path, local: true, class: 'testUserLoginForm' do |f|
+                  = f.hidden_field :email, :value => 'test@test.com'
+                  = f.hidden_field :password, :value => 'testuser1'
+                  = f.submit "こちら", class: 'tesuUserLoginButton'
       .signInUpFooter
         %ul.signInUpFooterList
           %li

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -22,10 +22,6 @@
                   = f.password_field :password_confirmation, placeholder: '上記と同じパスワードを入力してください', autocomplete: "new-password", class: 'signInUpInput'
                   %span{style: 'display:none'}, class: 'signInUpErrorMessage'}この項目は必須です
                 = f.submit "登録する", class: 'button-cv signInUpButton'
-            .testUserSignInForm
-              %span.testUserLoginText ※アカウント登録せず、ユーザー機能を試したい方は
-              = form_with model: @user, url: user_session_path, local: true, class: 'testUserLoginForm' do |f|
-                = f.submit "こちら", class: 'tesuUserLoginButton'
             .socialLogin
               %span{class: 'socialLoginTitle'}こちらもご利用いただけます
               .socialLoginContainer
@@ -42,6 +38,12 @@
               %a{href: '#', class: 'registerPolicyLink'}プライバシーポリシー
               に同意したものとみなされます。
             = render "devise/shared/links"
+            .testUserSignInForm
+              %span.testUserLoginText ※アカウント登録せず、ユーザー機能を試したい方は
+              = form_with model: @user, url: user_session_path, local: true, class: 'testUserLoginForm' do |f|
+                = f.hidden_field :email, :value => 'test@test.com'
+                = f.hidden_field :password, :value => 'testuser1'
+                = f.submit "こちら", class: 'tesuUserLoginButton'
       .signInUpFooter
         %ul.signInUpFooterList
           %li

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -22,6 +22,10 @@
                   = f.password_field :password_confirmation, placeholder: '上記と同じパスワードを入力してください', autocomplete: "new-password", class: 'signInUpInput'
                   %span{style: 'display:none'}, class: 'signInUpErrorMessage'}この項目は必須です
                 = f.submit "登録する", class: 'button-cv signInUpButton'
+            .testUserSignInForm
+              %span.testUserLoginText ※アカウント登録せず、ユーザー機能を試したい方は
+              = form_with model: @user, url: user_session_path, local: true, class: 'testUserLoginForm' do |f|
+                = f.submit "こちら", class: 'tesuUserLoginButton'
             .socialLogin
               %span{class: 'socialLoginTitle'}こちらもご利用いただけます
               .socialLoginContainer


### PR DESCRIPTION
## 概要
* 会員登録をしなくてもテストユーザーとしてログインして、マイページ等の会員限定機能を試せる様にする。

## 変更点
* `session/new.html.haml` と `register/new.html.haml`内に『※アカウント登録せず、ユーザー機能を試したい方はこちら』というリンクを設置。
* リンクをクリックするとvalueとして、`email: test@com`と`password: testsuer1`を送信し、ログイン処理をする。

## テスト結果とテスト項目
- [x] 会員登録画面の『※アカウント登録せず、ユーザー機能を試したい方はこちら』をクリックすると、テストユーザーとしてログインしてトップページにリダイレクトされる。
- [x] ログイン画面の『※アカウント登録せず、ユーザー機能を試したい方はこちら』をクリックすると、テストユーザーとしてログインしてトップページにリダイレクトされる。

## Issue番号
close #24