### PR TITLE
ユーザー情報の更新機能の実装

### DIFF
--- a/app/assets/stylesheets/pages/_mypage.scss
+++ b/app/assets/stylesheets/pages/_mypage.scss
@@ -1,11 +1,15 @@
 $userNameHeight: calc(100% / 4 * 3);
+@mixin user_image {
+  border-radius: 10px;
+  border: 1px solid gray;
+}
 .mypage_wrapper{
   background-image: url('mypage_image.jpg');
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
   min-height: 100vh;
-  width: 100vw;
+  width: 100%;
   position: relative;
   background-attachment: fixed;
   .mypage_main{
@@ -13,7 +17,7 @@ $userNameHeight: calc(100% / 4 * 3);
     top: 0;
     left: 0;
     height: 100vh;
-    width: 100%;
+    width: 1440px;
     background-color: rgba($color: black, $alpha: 0.5);
     .mypage_contents_head{
       height: 94px;
@@ -74,8 +78,7 @@ $userNameHeight: calc(100% / 4 * 3);
             width: 150px;
             margin: 17px;
             .user_image{
-              border-radius: 10px;
-              border: 1px solid gray;
+              @include user_image();
             }
           }
           .mypage_user_name_area{
@@ -106,13 +109,49 @@ $userNameHeight: calc(100% / 4 * 3);
         }
         .user_edit_main{
           @extend .mypage_user_info_head;
-          height: 500px;
+          height: 100%;
           display: block;
           color: black;
           padding: 0 17px;
           #link_main{
             font-size: 12px;
             border-bottom: 1px dotted black;
+          }
+          .edit_user{
+            padding-top: 17px;
+            text-align: end;
+            .field{
+              width: 100%;
+              margin-bottom: 10px;
+              .text-top{
+                vertical-align: top;
+              }
+              .edit_user_form{
+                width: calc(100% - 120px);
+                border: 1px solid gray;
+                border-radius: 6px;
+                padding: 5px;
+              }
+            }
+          }
+          .image_field{
+            text-align: left;
+            padding-left: 20px;
+            .text-top{
+              vertical-align: top;
+            }
+            .user_image{
+              @include user_image();
+            }
+            .hidden{
+              display: none;
+            }
+          }
+          .update_button{
+            margin: 17px 199px;
+            height: 54px;
+            width: 300px;
+            background-color: #90b200;
           }
         }
       }

--- a/app/assets/stylesheets/pages/_mypage.scss
+++ b/app/assets/stylesheets/pages/_mypage.scss
@@ -123,7 +123,7 @@ $userNameHeight: calc(100% / 4 * 3);
             .field{
               width: 100%;
               margin-bottom: 10px;
-              .text-top{
+              .text_top{
                 vertical-align: top;
               }
               .edit_user_form{
@@ -137,11 +137,12 @@ $userNameHeight: calc(100% / 4 * 3);
           .image_field{
             text-align: left;
             padding-left: 20px;
-            .text-top{
+            .text_top{
               vertical-align: top;
             }
             .user_image{
               @include user_image();
+              cursor: pointer;
             }
             .hidden{
               display: none;

--- a/app/assets/stylesheets/pages/_mypage.scss
+++ b/app/assets/stylesheets/pages/_mypage.scss
@@ -99,11 +99,21 @@ $userNameHeight: calc(100% / 4 * 3);
         .mypage_user_info_main{
           @extend .mypage_user_info_head;
           height: 250px;
-          width: 100%;
           margin-top: 20px;
           display: block;
           color: black;
           padding: 25px 17px;
+        }
+        .user_edit_main{
+          @extend .mypage_user_info_head;
+          height: 500px;
+          display: block;
+          color: black;
+          padding: 0 17px;
+          #link_main{
+            font-size: 12px;
+            border-bottom: 1px dotted black;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/pages/_password.scss
+++ b/app/assets/stylesheets/pages/_password.scss
@@ -33,17 +33,6 @@
       font-size: 12px;
       line-height: 18px;
     }
-    #password_main{
-      padding: 10px 0 5px 0;
-      border-bottom: 1px dotted #ccc;
-      a{
-        outline: none;
-      }
-      a:visited{
-        text-decoration: none;
-        color: #069;
-      }
-    }
     #contents_area{
       width: 740px;
       min-height: 450px;

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -128,3 +128,14 @@ img {
     }
   }
 }
+#link_main{
+  padding: 10px 0 5px 0;
+  border-bottom: 1px dotted #ccc;
+  a{
+    outline: none;
+  }
+  a:visited{
+    text-decoration: none;
+    color: #069;
+  }
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,7 +60,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :introduce])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :introduce, :image])
   end
 
   # The path used after sign up.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,9 +58,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
     resource.update_without_password(params)
   end
 
-  # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :introduce, :image])
+  end
+
+  def after_update_path_for(resource)
+    "/users/#{current_user.id}"
   end
 
   # The path used after sign up.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_account_update_params, only: [:update]
 
   def new
     @user = User.new
@@ -54,10 +54,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :introduce])
+  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,10 @@
 module UsersHelper
+
+  def user_image_attached?(user)
+    if user.image.attached?
+      image_tag user.image, alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
+    else
+      image_tag 'no_image.jpg', alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
+    end
+  end
 end

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -5,7 +5,7 @@
   / ヘッダー
   .password_main{align: 'center'}
     / トップページからの遷移リンクを表示
-    .menu{id: 'password_main', style: 'margin-bottom:0; text-align: left'}
+    .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
       = link_to 'トップ', root_path
       &nbsp;>&nbsp;
       = link_to '会員情報の確認・変更', '#'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -30,15 +30,19 @@
           = form_with model: @user, url: user_registration_path, local: true, class: 'edit_user' do |f|
             .field
               = f.label :お名前
-              = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name'
+              = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name', class: 'edit_user_form'
             .field
               = f.label :メールアドレス
-              = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
+              = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off', class: 'edit_user_form'
             .field
-              = f.label :自己紹介文
-              = f.text_area :introduce
-            .field
-              = f.label :アイコン画像
-              = f.file_field :image
-            = f.submit "更新する", class: 'button_cv signin_up_button'
+              = f.label :自己紹介文, class: 'text-top'
+              = f.text_area :introduce, size: '64x8', class: 'edit_user_form'
+            .image_field
+              = f.label :アイコン画像, class: 'text-top'
+              - unless @user.image.attached?
+                = image_tag 'no_image.jpg', alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
+              - else
+                = image_tag @user.image, alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
+              = f.file_field :image, class: 'hidden'
+            = f.submit "更新する", class: 'button_cv update_button'
 = render 'shared/leh_footer'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,45 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
+= form_with model: @user, url: user_registration_path, local: true, class: 'edit_user' do |f|
   .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
+    = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name'
   .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
+    = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
   .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+    = f.text_area :introduce
+  = f.submit "更新する", class: 'button_cv signin_up_button'
+
+-# %h2
+-#   Edit #{resource_name.to_s.humanize}
+-# = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+-#   = render "devise/shared/error_messages", resource: resource
+-#   .field
+-#     = f.label :email
+-#     %br/
+-#     = f.email_field :email, autofocus: true, autocomplete: "email"
+-#   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+-#     %div
+-#       Currently waiting confirmation for: #{resource.unconfirmed_email}
+-#   .field
+-#     = f.label :password
+-#     %i (leave blank if you don't want to change it)
+-#     %br/
+-#     = f.password_field :password, autocomplete: "new-password"
+-#     - if @minimum_password_length
+-#       %br/
+-#       %em
+-#         = @minimum_password_length
+-#         characters minimum
+-#   .field
+-#     = f.label :password_confirmation
+-#     %br/
+-#     = f.password_field :password_confirmation, autocomplete: "new-password"
+-#   .field
+-#     = f.label :current_password
+-#     %i (we need your current password to confirm your changes)
+-#     %br/
+-#     = f.password_field :current_password, autocomplete: "current-password"
+-#   .actions
+-#     = f.submit "Update"
+-# %h3 Cancel my account
+-# %p
+-#   Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+-# = link_to "Back", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -5,6 +5,8 @@
     = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
   .field
     = f.text_area :introduce
+  .field
+    = f.file_field :image
   = f.submit "更新する", class: 'button_cv signin_up_button'
 
 -# %h2

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -22,14 +22,23 @@
             %li.mypage_user_side
               = link_to '行った場所', '#', class: 'mypage_user_side_text'
       .mypage_contents_main_right
-        = form_with model: @user, url: user_registration_path, local: true, class: 'edit_user' do |f|
-          .field
-            = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name'
-          .field
-            = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
-          .field
-            = f.text_area :introduce
-          .field
-            = f.file_field :image
-          = f.submit "更新する", class: 'button_cv signin_up_button'
+        .user_edit_main
+          .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
+            = link_to 'マイページトップ', "/users/#{current_user.id}"
+            &nbsp;>&nbsp;
+            %strong 会員情報の確認・変更
+          = form_with model: @user, url: user_registration_path, local: true, class: 'edit_user' do |f|
+            .field
+              = f.label :お名前
+              = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name'
+            .field
+              = f.label :メールアドレス
+              = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
+            .field
+              = f.label :自己紹介文
+              = f.text_area :introduce
+            .field
+              = f.label :アイコン画像
+              = f.file_field :image
+            = f.submit "更新する", class: 'button_cv signin_up_button'
 = render 'shared/leh_footer'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -35,13 +35,11 @@
               = f.label :メールアドレス
               = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off', class: 'edit_user_form'
             .field
-              = f.label :自己紹介文, class: 'text-top'
+              = f.label :自己紹介文, class: 'text_top'
               = f.text_area :introduce, size: '64x8', class: 'edit_user_form'
             .image_field
-              = f.label :アイコン画像, class: 'text-top'
-              - unless @user.image.attached?
-                = image_tag 'no_image.jpg', alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
-              - else
+              = f.label :アイコン画像, class: 'text_top'
+              = f.label :image do
                 = image_tag @user.image, alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
               = f.file_field :image, class: 'hidden'
             = f.submit "更新する", class: 'button_cv update_button'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,47 +1,35 @@
-= form_with model: @user, url: user_registration_path, local: true, class: 'edit_user' do |f|
-  .field
-    = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name'
-  .field
-    = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
-  .field
-    = f.text_area :introduce
-  .field
-    = f.file_field :image
-  = f.submit "更新する", class: 'button_cv signin_up_button'
-
--# %h2
--#   Edit #{resource_name.to_s.humanize}
--# = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
--#   = render "devise/shared/error_messages", resource: resource
--#   .field
--#     = f.label :email
--#     %br/
--#     = f.email_field :email, autofocus: true, autocomplete: "email"
--#   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
--#     %div
--#       Currently waiting confirmation for: #{resource.unconfirmed_email}
--#   .field
--#     = f.label :password
--#     %i (leave blank if you don't want to change it)
--#     %br/
--#     = f.password_field :password, autocomplete: "new-password"
--#     - if @minimum_password_length
--#       %br/
--#       %em
--#         = @minimum_password_length
--#         characters minimum
--#   .field
--#     = f.label :password_confirmation
--#     %br/
--#     = f.password_field :password_confirmation, autocomplete: "new-password"
--#   .field
--#     = f.label :current_password
--#     %i (we need your current password to confirm your changes)
--#     %br/
--#     = f.password_field :current_password, autocomplete: "current-password"
--#   .actions
--#     = f.submit "Update"
--# %h3 Cancel my account
--# %p
--#   Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
--# = link_to "Back", :back
+= render 'shared/leh_header'
+.mypage_wrapper
+  .mypage_main
+    .mypage_contents_head
+      %ul.mypage_contents_number_list
+        %li.mypage_contents_number
+          お気に入りした場所 0
+        %li.mypage_contents_number
+          口コミ数 0
+        %li.mypage_contents_number
+          行った場所 0
+    .mypage_contents_main
+      .mypage_contents_main_left
+        .mypage_user_setting_wrapper
+          %ul.mypage_user_side_list
+            %li.mypage_user_side
+              = link_to '会員情報の確認・変更', edit_user_registration_path, class: 'mypage_user_side_text'
+            %li.mypage_user_side
+              = link_to 'お気に入りした場所', '#', class: 'mypage_user_side_text'
+            %li.mypage_user_side
+              = link_to '今までの口コミ', '#', class: 'mypage_user_side_text'
+            %li.mypage_user_side
+              = link_to '行った場所', '#', class: 'mypage_user_side_text'
+      .mypage_contents_main_right
+        = form_with model: @user, url: user_registration_path, local: true, class: 'edit_user' do |f|
+          .field
+            = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name'
+          .field
+            = f.email_field :email, autocomplete: "email", autocorrect: 'off', autocapitalize: 'off'
+          .field
+            = f.text_area :introduce
+          .field
+            = f.file_field :image
+          = f.submit "更新する", class: 'button_cv signin_up_button'
+= render 'shared/leh_footer'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -40,7 +40,7 @@
             .image_field
               = f.label :アイコン画像, class: 'text_top'
               = f.label :image do
-                = image_tag @user.image, alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
+                = user_image_attached?(@user)
               = f.file_field :image, class: 'hidden'
             = f.submit "更新する", class: 'button_cv update_button'
 = render 'shared/leh_footer'

--- a/app/views/shared/_leh_header.html.haml
+++ b/app/views/shared/_leh_header.html.haml
@@ -7,7 +7,7 @@
       .sign_login_wrapper
         %ul.sign_login
           -# 会員登録画面とログイン画面の時はリンクを表示させない。
-          - unless controller_name == 'registrations' || controller_name == 'sessions'
+          - unless (controller_name == 'registrations' && action_name != 'edit') || controller_name == 'sessions'
             -# ユーザーがログインしていなければ『ログイン』か『会員登録』を表示させる。
             - unless user_signed_in?
               %li

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -24,10 +24,7 @@
       .mypage_contents_main_right
         .mypage_user_info_head
           .mypage_user_image
-            - unless @user.image.attached?
-              = image_tag 'no_image.jpg', alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
-            - else
-              = image_tag @user.image, alt: 'no_image', height: '150px', width: '150px', class: 'user_image'
+            = user_image_attached?(@user)
           .mypage_user_name_area
             .mypage_user_name1
               = @user.name


### PR DESCRIPTION
## 概要
* ユーザー情報が登録の際に名前とメールアドレスしか設定できていなかったので、自己紹介文やアイコン画像を変更できる様な機能を実装。

## 変更点
* `registrations/edit.html.haml` 内に『名前』『メールアドレス』『自己紹介文』『アイコン画像』を変更するフォームを設置。
* 『アイコン画像』は、画像部分をクリックすると変更用の画像を選択するウィンドウが表示される。
* 『更新する』ボタンをクリックすると、マイページトップへ遷移する様に'registrations_controller.rb'内にコード記述。
* ユーザーにアイコン画像があるかどうかを確認する為の処理をヘルパーメソッドとして、'users_helper.rb'に切り出してメソッドを定義。

## テスト結果とテスト項目
- [x] 『会員情報確認・変更』ボタンをクリックすると情報変更用のページへ遷移する。
- [x] アイコン画像をクリックすると、新しい画像を選択するウィンドウが表示される。
- [x] 『更新する』ボタンをクリックすると、入力した情報がユーザー情報に上書きされて、マイページトップへリダイレクトされる。

## Issue番号
close #30 