### PR TITLE
ユーザー情報更新時の画像変更を表示する機能実装

### DIFF
--- a/app/javascript/mypage.js
+++ b/app/javascript/mypage.js
@@ -1,0 +1,11 @@
+$(document).on('change', '#user_image', function(e){
+  // 変更するために選択した画像ファイルを変数に代入する。
+  const imageFile = e.target.files[0];
+  const fileReader = new FileReader();
+
+  // 画像ファイルをurlにエンコードする。
+  fileReader.readAsDataURL(imageFile);
+  fileReader.onload = () => {
+    $('.user_image').attr('src', fileReader.result);
+  };
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,8 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("jquery")
+require("mypage.js")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery/src/jquery',
+    jQuery: 'jquery/src/jquery'
+  })
+)
+
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0-alpha",
     "@rails/ujs": "^6.0.0-alpha",
     "@rails/webpacker": "4.3.0",
+    "jquery": "^3.5.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4006,6 +4006,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
## 概要
* アイコン画像変更用の画像を選択した際に、選択された画像のプレビューが表示されていなかったので、表示される様に修正。

## 変更点
* `mypage.js`に`registrations/edit.html.haml`内で画像選択された時に、その選択された画像のURLに`image_tag`の画像URLを置き換え実施。

## テスト結果とテスト項目
- [x] ユーザーアイコンの画像選択をすると、選択した画像がアイコン画像欄にプレビューとして表示される。

## Issue番号
close #37 