### PR TITLE
'マイページ'上部のお気に入り数等の数値をユーザー毎に変更する様に'show.html.haml'内のコード修正

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -4,11 +4,11 @@
     .mypage_contents_head
       %ul.mypage_contents_number_list
         %li.mypage_contents_number
-          お気に入りした場所 0
+          = "お気に入りした場所 #{@user.favorites.length.to_s(:delimited)}"
         %li.mypage_contents_number
-          口コミ数 0
+          = "口コミ数 #{@user.reviews.length.to_s(:delimited)}"
         %li.mypage_contents_number
-          行った場所 0
+          = "行った場所 #{@user.histories.length.to_s(:delimited)}"
     .mypage_contents_main
       .mypage_contents_main_left
         .mypage_user_setting_wrapper


### PR DESCRIPTION
## 概要
* `マイページ `上部の『お気に入り数』等の数値が'0'固定になっていたので、ユーザー毎に対応した表示へ変更する。

## 変更点
* ユーザー毎にお気に入りしているアクティビティ数や、口コミ数等を表示できる様に`show.html.haml`に渡されている`@user`から情報を取得して表示させる様にコードを修正。

## テスト結果とテスト項目
- [x] 『お気に入り数』等の数値がユーザー毎に対応した数値になっている。

## Issue番号
close #34 