### PR TITLE
'アクティビティ詳細表示ページ'のビュー調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "pages/search";
+@import "pages/experiences";

--- a/app/assets/stylesheets/experiences.scss
+++ b/app/assets/stylesheets/experiences.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the experiences controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -3,9 +3,14 @@ $contentLeftMargin: 30px;
 @mixin areaLinkTo {
   font-weight: bold;
   margin-right: 30px;
-  }
   .link_to{
     margin: -1px 6px 0 8px;
+  }
+}
+@mixin center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .menu{
   font-size: 10px;
@@ -116,8 +121,13 @@ $contentLeftMargin: 30px;
               width: 86px;
               border-radius: 4px 4px 0 0;
               border: 2px solid #ffa500;
-              border-bottom: 2px solid #ffffff;
               margin-right: 4px;
+              text-align: center;
+              cursor: pointer;
+              &.active_tab{
+                border-bottom: 2px solid #ffffff;
+                cursor: auto;
+              }
             }
           }
         }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -158,7 +158,7 @@ $colorBlack: #333333;
           .content_picture{
             height: 370px;
             width: 490px;
-            background-color: black;
+            border: 1px solid $gray;
           }
           .content_score{
             height: 180px;

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -14,11 +14,23 @@ $contentLeftMargin: 30px;
     margin-right: $contentLeftMargin;
     .show_left_info{
       height: 200px;
-      background-color: black;
+      display: flex;
+      justify-content: space-between;
+      .show_info_left{
+        height: 100%;
+        width: 50px;
+        margin: 25px 0;
+        background-color: black;
+      }
+      .show_info_right{
+        @extend .show_info_left;
+        height: 140px;
+        width: 170px;
+      }
     }
   }
   .show_content_right{
-    background-color: black;
+    // background-color: black;
     height: 1000px;
     width: calc(100% - #{$contentLeftWidth} - #{$contentLeftMargin});
   }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -1,5 +1,6 @@
 $contentLeftWidth: 740px;
 $contentLeftMargin: 30px;
+$colorBlack: #333333;
 @mixin center {
   display: flex;
   justify-content: center;
@@ -24,7 +25,7 @@ $contentLeftMargin: 30px;
         height: 100%;
         width: 500px;
         margin: 25px 0;
-        color: #333333;
+        color: $colorBlack;
         .show_info_name{
           display: flex;
           .experience_name{
@@ -119,7 +120,8 @@ $contentLeftMargin: 30px;
             height: 43px;
             width: 86px;
             border-radius: 4px 4px 0 0;
-            border: 2px solid #ffa500;
+            border: 2px solid $gray;
+            border-bottom: 2px solid #ffa500;
             margin-right: 4px;
             padding: 12px 0 0;
             font-size: 12px;
@@ -132,6 +134,7 @@ $contentLeftMargin: 30px;
             &.active_tab{
               color: orangered;
               font-weight: bold;
+              border: 2px solid #ffa500;
               border-bottom: 2px solid #ffffff;
               cursor: auto;
             }
@@ -139,6 +142,25 @@ $contentLeftMargin: 30px;
           .tab_2line{
             @extend .tab;
             padding: 6px 0 0;
+          }
+        }
+      }
+      &_content{
+        height: 1000px;
+        margin-top: 16px;
+        .experience_name{
+          font-size: 18px;
+          font-weight: bold;
+          margin: 0 0 13px 3px;
+          color: $colorBlack;
+        }
+        .picture_score{
+          display: flex;
+          height: 1000px;
+          .content_picture{
+            height: 370px;
+            width: 490px;
+            background-color: black;
           }
         }
       }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -20,12 +20,39 @@ $contentLeftMargin: 30px;
         height: 100%;
         width: 50px;
         margin: 25px 0;
-        background-color: black;
       }
       .show_info_right{
         @extend .show_info_left;
         height: 140px;
         width: 170px;
+        .post_reviews{
+          height: 37px;
+          line-height: 37px;
+          font-size: 20px;
+          border: 1px solid $gray;
+          border-radius: 3px;
+          text-align: center;
+          margin-bottom: 5px;
+        }
+        .share_act{
+          @extend .post_reviews;
+        }
+        &_down{
+          display: flex;
+          .favorite{
+            height: 25px;
+            width: calc((170px - 5px) / 2) ;
+            line-height: 25px;
+            font-size: 15px;
+            border: 1px solid $gray;
+            border-radius: 3px;
+            padding-left: 5px;
+          }
+          .have_been_place{
+            @extend .favorite;
+            margin-left: 5px;
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -105,9 +105,22 @@ $contentLeftMargin: 30px;
     .show_left_main{
       height: 1000px;
       &_tab{
-        height: 43px;
-        border-bottom: 2px solid #ffa500;
-        background-color: black;
+        .experience_tabs{
+          display: flex;
+          height: 43px;
+          border-bottom: 2px solid #ffa500;
+          padding: 0 12px;
+          @for $i from 1 through 7 {
+            .tab#{$i}{
+              height: 43px;
+              width: 86px;
+              border-radius: 4px 4px 0 0;
+              border: 2px solid #ffa500;
+              border-bottom: 2px solid #ffffff;
+              margin-right: 4px;
+            }
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -2,4 +2,7 @@
   // background-color: black;
   width: 950px;
   margin: 0 auto;
+  .menu{
+    font-size: 10px;
+  }
 }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -1,5 +1,12 @@
 $contentLeftWidth: 740px;
 $contentLeftMargin: 30px;
+@mixin areaLinkTo {
+  font-weight: bold;
+  margin-right: 30px;
+  }
+  .link_to{
+    margin: -1px 6px 0 8px;
+}
 .menu{
   font-size: 10px;
   margin: 0 auto;
@@ -20,7 +27,7 @@ $contentLeftMargin: 30px;
         height: 100%;
         width: 500px;
         margin: 25px 0;
-        // background-color: black;
+        color: #333333;
         .show_info_name{
           display: flex;
           .experience_name{
@@ -30,7 +37,7 @@ $contentLeftMargin: 30px;
           }
         }
         .show_info_score{
-          @include exp_score;
+          @include expScore;
           padding-top: 5px;
           .rating_point{
             font-size: 16px;
@@ -38,6 +45,28 @@ $contentLeftMargin: 30px;
           }
           .review_count{
             font-size: 12px;
+          }
+        }
+        .black{
+          height: 19px;
+          width: 100%;
+          margin: 3px 0;
+          background-color: black;
+        }
+        .area_wrapper{
+          display: flex;
+          font-size: 12px;
+          margin-top: 12px;
+          .area{
+            @include areaLinkTo();
+          }
+        }
+        .genre_wrapper{
+          @extend .area_wrapper;
+          margin-top: 5px;
+          .genre{
+            @include areaLinkTo();
+            margin-right: 19px;
           }
         }
       }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -119,6 +119,7 @@ $colorBlack: #333333;
           .tab{
             height: 43px;
             width: 86px;
+            color: $colorBlack;
             border-radius: 4px 4px 0 0;
             border: 2px solid $gray;
             border-bottom: 2px solid #ffa500;
@@ -151,8 +152,8 @@ $colorBlack: #333333;
         .experience_name{
           font-size: 18px;
           font-weight: bold;
-          margin: 0 0 13px 3px;
           color: $colorBlack;
+          margin: 0 0 13px 3px;
         }
         .picture_score{
           display: flex;
@@ -166,7 +167,49 @@ $colorBlack: #333333;
           .content_score{
             height: 180px;
             width: 240px;
-            background-color: black;
+            border: 1px solid $gray;
+            &_list{
+              padding: 9px 8px;
+              color: $colorBlack;
+              .list_title{
+                font-size: 14px;
+                font-weight: bold;
+              }
+              .list_score{
+                font-size: 12px;
+                margin-top: 8px;
+                display: flex;
+                .evaluation{
+                  width: 78px;
+                  display: block;
+                }
+                .persent{
+                  width: 27px;
+                  display: block;
+                  text-align: end;
+                  margin-right: 11px;
+                }
+                .persent_graph{
+                  margin-top: 2px;
+                  position: relative;
+                  height: 14px;
+                  width: 102px;
+                  &_front{
+                    height: 100%;
+                    width: 0%;
+                    background-color: #ffa500;
+                  }
+                  &_back{
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    height: 100%;
+                    width: 100%;
+                    border: 1px solid #ffa500;
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -156,10 +156,16 @@ $colorBlack: #333333;
         }
         .picture_score{
           display: flex;
+          justify-content: space-between;
           height: 1000px;
           .content_picture{
             height: 370px;
             width: 490px;
+            background-color: black;
+          }
+          .content_score{
+            height: 180px;
+            width: 240px;
             background-color: black;
           }
         }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -1,8 +1,25 @@
-.show_content_area{
-  // background-color: black;
-  width: 950px;
+$contentLeftWidth: 740px;
+$contentLeftMargin: 30px;
+.menu{
+  font-size: 10px;
   margin: 0 auto;
-  .menu{
-    font-size: 10px;
+  width: 950px;
+}
+.show_content_wrapper{
+  @extend .menu;
+  display: flex;
+  .show_content_left{
+    height: 1000px;
+    width: $contentLeftWidth;
+    margin-right: $contentLeftMargin;
+    .show_left_info{
+      height: 200px;
+      background-color: black;
+    }
+  }
+  .show_content_right{
+    background-color: black;
+    height: 1000px;
+    width: calc(100% - #{$contentLeftWidth} - #{$contentLeftMargin});
   }
 }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -158,7 +158,7 @@ $colorBlack: #333333;
         .picture_score{
           display: flex;
           justify-content: space-between;
-          height: 1000px;
+          margin-bottom: 30px;
           .content_picture{
             height: 370px;
             width: 490px;
@@ -196,7 +196,6 @@ $colorBlack: #333333;
                   width: 102px;
                   &_front{
                     height: 100%;
-                    width: 0%;
                     background-color: #ffa500;
                   }
                   &_back{
@@ -209,6 +208,38 @@ $colorBlack: #333333;
                   }
                 }
               }
+            }
+          }
+        }
+        .dq{
+          height: 145px;
+        }
+        .business_info{
+          height: 71px;
+        }
+        .business_info2{
+          display: flex;
+          height: 36px;
+          border: 1px solid $gray;
+          color: $colorBlack;
+          .business_info_title{
+            height: 100%;
+            width: 175px;
+            font-size: 12px;
+            font-weight: bold;
+            padding: 8px 0 0 8px;
+            border-right: 1px solid $gray;
+            background-color: #eaeaea;
+          }
+          .business_info_main{
+            display: flex;
+            font-size: 12px;
+            padding: 8px 0 0 8px;
+            &_postalcode{
+              margin-right: 16px;
+            }
+            &_address{
+              margin-right: 4px;
             }
           }
         }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -192,6 +192,7 @@ $colorBlack: #333333;
                   width: 102px;
                   &_front{
                     height: 100%;
+                    width: 0%;
                     background-color: #ffa500;
                   }
                   &_back{

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -15,14 +15,12 @@ $colorBlack: #333333;
   @extend .menu;
   display: flex;
   .show_content_left{
-    height: 1000px;
     width: $contentLeftWidth;
     margin-right: $contentLeftMargin;
     .show_left_info{
       display: flex;
       justify-content: space-between;
       .show_info_left{
-        height: 100%;
         width: 500px;
         margin: 25px 0;
         color: $colorBlack;
@@ -109,7 +107,6 @@ $colorBlack: #333333;
       }
     }
     .show_left_main{
-      height: 1000px;
       &_tab{
         .experience_tabs{
           display: flex;
@@ -147,7 +144,6 @@ $colorBlack: #333333;
         }
       }
       &_content{
-        height: 1000px;
         margin-top: 16px;
         .experience_name{
           font-size: 18px;
@@ -211,13 +207,7 @@ $colorBlack: #333333;
             }
           }
         }
-        .dq{
-          height: 145px;
-        }
         .business_info{
-          height: 71px;
-        }
-        .business_info2{
           display: flex;
           height: 36px;
           border: 1px solid $gray;
@@ -243,11 +233,15 @@ $colorBlack: #333333;
             }
           }
         }
+        .business_info2{
+          @extend .business_info;
+          border-top: 0;
+          margin-bottom: 30px;
+        }
       }
     }
   }
   .show_content_right{
-    height: 1000px;
     width: calc(100% - #{$contentLeftWidth} - #{$contentLeftMargin});
   }
 }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -18,8 +18,28 @@ $contentLeftMargin: 30px;
       justify-content: space-between;
       .show_info_left{
         height: 100%;
-        width: 50px;
+        width: 500px;
         margin: 25px 0;
+        // background-color: black;
+        .show_info_name{
+          display: flex;
+          .experience_name{
+            font-size: 24px;
+            font-weight: bold;
+            margin: -1px 0 0 3px;
+          }
+        }
+        .show_info_score{
+          @include exp_score;
+          padding-top: 5px;
+          .rating_point{
+            font-size: 16px;
+            margin-top: 1px;
+          }
+          .review_count{
+            font-size: 12px;
+          }
+        }
       }
       .show_info_right{
         @extend .show_info_left;
@@ -62,7 +82,6 @@ $contentLeftMargin: 30px;
     }
   }
   .show_content_right{
-    // background-color: black;
     height: 1000px;
     width: calc(100% - #{$contentLeftWidth} - #{$contentLeftMargin});
   }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -1,0 +1,5 @@
+.show_content_area{
+  // background-color: black;
+  width: 950px;
+  margin: 0 auto;
+}

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -20,7 +20,6 @@ $contentLeftMargin: 30px;
     width: $contentLeftWidth;
     margin-right: $contentLeftMargin;
     .show_left_info{
-      height: 200px;
       display: flex;
       justify-content: space-between;
       .show_info_left{
@@ -46,12 +45,6 @@ $contentLeftMargin: 30px;
           .review_count{
             font-size: 12px;
           }
-        }
-        .black{
-          height: 19px;
-          width: 100%;
-          margin: 3px 0;
-          background-color: black;
         }
         .area_wrapper{
           display: flex;
@@ -107,6 +100,14 @@ $contentLeftMargin: 30px;
             margin-left: 5px;
           }
         }
+      }
+    }
+    .show_left_main{
+      height: 1000px;
+      &_tab{
+        height: 43px;
+        border-bottom: 2px solid #ffa500;
+        background-color: black;
       }
     }
   }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -1,12 +1,5 @@
 $contentLeftWidth: 740px;
 $contentLeftMargin: 30px;
-@mixin areaLinkTo {
-  font-weight: bold;
-  margin-right: 30px;
-  .link_to{
-    margin: -1px 6px 0 8px;
-  }
-}
 @mixin center {
   display: flex;
   justify-content: center;
@@ -56,15 +49,22 @@ $contentLeftMargin: 30px;
           font-size: 12px;
           margin-top: 12px;
           .area{
-            @include areaLinkTo();
+            font-weight: bold;
+            margin-right: 40px;
+          }
+          .link_to{
+            margin: -1px 6px 0 8px;
           }
         }
         .genre_wrapper{
           @extend .area_wrapper;
           margin-top: 5px;
           .genre{
-            @include areaLinkTo();
-            margin-right: 19px;
+            font-weight: bold;
+            margin-right: 29px;
+          }
+          .link_to{
+            margin: -1px 6px 0 8px;
           }
         }
       }
@@ -115,20 +115,30 @@ $contentLeftMargin: 30px;
           height: 43px;
           border-bottom: 2px solid #ffa500;
           padding: 0 12px;
-          @for $i from 1 through 7 {
-            .tab#{$i}{
-              height: 43px;
-              width: 86px;
-              border-radius: 4px 4px 0 0;
-              border: 2px solid #ffa500;
-              margin-right: 4px;
-              text-align: center;
-              cursor: pointer;
-              &.active_tab{
-                border-bottom: 2px solid #ffffff;
-                cursor: auto;
-              }
+          .tab{
+            height: 43px;
+            width: 86px;
+            border-radius: 4px 4px 0 0;
+            border: 2px solid #ffa500;
+            margin-right: 4px;
+            padding: 12px 0 0;
+            font-size: 12px;
+            line-height: 15px;
+            text-align: center;
+            cursor: pointer;
+            .number{
+              font-size: 11px;
             }
+            &.active_tab{
+              color: orangered;
+              font-weight: bold;
+              border-bottom: 2px solid #ffffff;
+              cursor: auto;
+            }
+          }
+          .tab_2line{
+            @extend .tab;
+            padding: 6px 0 0;
           }
         }
       }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -33,6 +33,7 @@ $contentLeftMargin: 30px;
           border-radius: 3px;
           text-align: center;
           margin-bottom: 5px;
+          position: relative;
         }
         .share_act{
           @extend .post_reviews;
@@ -47,6 +48,10 @@ $contentLeftMargin: 30px;
             border: 1px solid $gray;
             border-radius: 3px;
             padding-left: 5px;
+            position: relative;
+            .fa-star{
+              color: #ffa500;
+            }
           }
           .have_been_place{
             @extend .favorite;

--- a/app/assets/stylesheets/pages/_search.scss
+++ b/app/assets/stylesheets/pages/_search.scss
@@ -115,7 +115,7 @@ $gray: #ccc;
             }
           }
           .experience_score{
-            @include exp_score;
+            @include expScore;
           }
           &_place{
             margin-top: -4px;

--- a/app/assets/stylesheets/pages/_search.scss
+++ b/app/assets/stylesheets/pages/_search.scss
@@ -114,39 +114,8 @@ $gray: #ccc;
               font-weight: bold;
             }
           }
-          &_score{
-            display: flex;
-            .star_rating{
-              margin-right: 6px;
-              width: 5em;
-              line-height: 22px;
-              font-size: 22px;
-              position: relative;
-              &_front{
-                position: absolute;
-                top: 0;
-                left: 0;
-                overflow: hidden;
-                color: #ffa500;
-              }
-              &_back{
-                color: $gray;
-              }
-            }
-            .rating_point{
-              color: black;
-              font-weight: bold;
-              line-height: 26px;
-            }
-            .review_count{
-              @extend .rating_point;
-              font-weight: unset;
-              font-size: 12px;
-              line-height: 25px;
-            }
-            .review_link{
-              color: $linkColor;
-            }
+          .experience_score{
+            @include exp_score;
           }
           &_place{
             margin-top: -4px;

--- a/app/assets/stylesheets/pages/_search.scss
+++ b/app/assets/stylesheets/pages/_search.scss
@@ -127,7 +127,7 @@ $gray: #ccc;
                 top: 0;
                 left: 0;
                 overflow: hidden;
-                color: orange;
+                color: #ffa500;
               }
               &_back{
                 color: $gray;

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -1,4 +1,38 @@
 $transition: .2s ease-in-out;
+@mixin exp_score {
+  display: flex;
+  .star_rating{
+    margin-right: 6px;
+    width: 5em;
+    line-height: 22px;
+    font-size: 22px;
+    position: relative;
+    &_front{
+      position: absolute;
+      top: 0;
+      left: 0;
+      overflow: hidden;
+      color: #ffa500;
+    }
+    &_back{
+      color: $gray;
+    }
+  }
+  .rating_point{
+    color: black;
+    font-weight: bold;
+    line-height: 26px;
+  }
+  .review_count{
+    @extend .rating_point;
+    font-weight: unset;
+    font-size: 12px;
+    line-height: 25px;
+  }
+  .review_link{
+    color: $linkColor;
+  }
+}
 *, :after, :before{
   box-sizing: border-box;
   margin: 0;

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -1,5 +1,5 @@
 $transition: .2s ease-in-out;
-@mixin exp_score {
+@mixin expScore {
   display: flex;
   .star_rating{
     margin-right: 6px;
@@ -47,10 +47,10 @@ body{
 div{
   display: block;
 }
-a:link, a:visited{
-  text-decoration: unset;
-  color: #484848;
-}
+// a:link, a:visited{
+//   text-decoration: unset;
+//   color: #484848;
+// }
 p{
   display: block;
   margin-block-start: 1em;
@@ -178,4 +178,7 @@ img {
   a:visited{
     color: #069;
   }
+}
+.link_to{
+  color: blue;
 }

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -35,6 +35,13 @@ li{
 img {
   vertical-align: bottom;
 }
+.btn{
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
 .leh_header{
   .header_wrapper{
     padding: 10px 190px 0 50px;

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -5,6 +5,8 @@ class ExperiencesController < ApplicationController
 
   def show
     @experience = Experience.find(params[:id])
+    @scores = []
+    Review.where(experience_id: @experience.id).each { |review| @scores << review.score }
   end
 
   def edit

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -7,7 +7,7 @@ class ExperiencesController < ApplicationController
     @experience = Experience.find(params[:id])
     @scores = []
     Review.where(experience_id: @experience.id).each { |review| @scores << review.score }
-    @evalutions = ['不満','やや不満','普通','やや満足','満足']
+    @evalutions = %w[不満 やや不満 普通 やや満足 満足]
   end
 
   def edit

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -7,6 +7,7 @@ class ExperiencesController < ApplicationController
     @experience = Experience.find(params[:id])
     @scores = []
     Review.where(experience_id: @experience.id).each { |review| @scores << review.score }
+    @evalutions = ['不満','やや不満','普通','やや満足','満足']
   end
 
   def edit

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -10,7 +10,8 @@ $(window).on('load',function(){
     'assets/shopping_icon.png'
   ];
   const url = location.pathname;
-  const conditions = (url == '/shopping') || (url == '/landmark') || (url == '/leisure') || (url == '/rentacar') || (url == '/dinner') || (url == '/hotel');
+  console.log(url);
+  const conditions = (url == '/shopping') || (url == '/landmark') || (url == '/leisure') || (url == '/rentacar') || (url == '/dinner') || (url == '/hotel') || (url == '/experiences');
   if(conditions) {
     // 'category_id'を取得して、その'id'に対応したアイコン画像を配列から取得して表示させる。
     const categoryIcon = $('#category_icon')[0];

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -10,15 +10,15 @@ $(window).on('load',function(){
     'assets/shopping_icon.png'
   ];
   const url = location.pathname;
-  console.log(url);
-  const conditions = (url == '/shopping') || (url == '/landmark') || (url == '/leisure') || (url == '/rentacar') || (url == '/dinner') || (url == '/hotel') || (url == '/experiences');
+  const conditions = (url == '/shopping') || (url == '/landmark') || (url == '/leisure') || (url == '/rentacar') || (url == '/dinner') || (url == '/hotel');
   if(conditions) {
     // 'category_id'を取得して、その'id'に対応したアイコン画像を配列から取得して表示させる。
     const categoryIcon = $('#category_icon')[0];
     const categoryId = $('#category_id')[0].innerText;
     categoryIcon.src = categoryIcons[categoryId - 1];
-
-    // exp.scoreクラスを複数取得して、ノードリストから配列へ変換し、各要素毎に処理をしていく。
+  }
+  if(conditions || (/\/experiences\/[0-9]{1,}/.test(url))) {
+    // exp_scoreクラスを複数取得して、ノードリストから配列へ変換し、各要素毎に処理をしていく。
     const expScoreArray = Array.from($('.exp_score'));
     expScoreArray.forEach((element, index) => {
       const expScore = element.innerText;

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -23,13 +23,22 @@ $(window).on('load',function(){
     expScoreArray.forEach((element, index) => {
       const expScore = element.innerText;
       // 'expScore'に'20'を乗算することにより'%'の数値にして、`star_rating`の'width'プロパティの値に設定する。
-      const starRatingPersent = expScore * 20;
-      $(`#star_rating${index}`).css('width', `${starRatingPersent}%`);
+      const starRatingPercent = expScore * 20;
+      $(`#star_rating${index}`).css('width', `${starRatingPercent}%`);
+    });
+  }
+  // 詳細ページの5段階評価ごとの'%'を取得して数値に対応したグラフを表示させる。
+  if((/\/experiences\/[0-9]{1,}/.test(url))) {
+    const showScoreArray = Array.from($('[id*="score_"]'));
+    showScoreArray.reverse().forEach((element, index) => {
+      const percent = element.innerText.match(/\d+/)[0];
+      $(`#graph_score${index + 1}`).css('width', `${percent}%`);
     });
   }
 });
 
 $(function(){
+  // 'id名'に'change'と入っている要素をホバーするとリンクの表示を変更させる。
   $('[id^="change"]').on('mouseover',function(){
     $(this).addClass('link_hover');
   });

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Review < ApplicationRecord
-  extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :score
   belongs_to :user
   belongs_to :experience
 

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -6,6 +6,6 @@ class Score < ActiveHash::Base
     { id: 1, name: '★1.0以上' },
     { id: 2, name: '★2.0以上' },
     { id: 3, name: '★3.0以上' },
-    { id: 4, name: '★4.0以上' }
+    { id: 4, name: '★4.0以上' },
   ]
 end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -6,6 +6,6 @@ class Score < ActiveHash::Base
     { id: 1, name: '★1.0以上' },
     { id: 2, name: '★2.0以上' },
     { id: 3, name: '★3.0以上' },
-    { id: 4, name: '★4.0以上' },
+    { id: 4, name: '★4.0以上' }
   ]
 end

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -43,7 +43,7 @@
           .content_main_header
             .content_main_header_name
               = link_to "#{exp.name}", "experiences/#{exp.id}", id: 'change_link', class: 'show_experiences'
-            .content_main_header_score
+            .experience_score
               .star_rating
                 %div{id: "star_rating#{index}", class: 'star_rating_front'}
                   ★★★★★

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -68,6 +68,8 @@
             = icon('fas', 'shoe-prints',class: 'fa-rotate-270')
             行った
             = link_to '', '#', class: 'btn'
+    .show_left_main
+      .show_left_main_tab
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -14,6 +14,8 @@
 .show_content_wrapper
   .show_content_left
     .show_left_info
+      .show_info_left
+      .show_info_right
   .show_content_right
 %h1
   = "#{@experience.name}の詳細"

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -71,15 +71,27 @@
     .show_left_main
       .show_left_main_tab
         %ul.experience_tabs
-          %li{class: 'tab1 active_tab'}
+          %li{class: 'tab active_tab'}
             %span
               概要
-          %li.tab2
-          %li.tab3
-          %li.tab4
-          %li.tab5
-          %li.tab6
-          %li.tab7
+          %li.tab_2line
+            %span
+              口コミ
+            %br/
+            %span.number
+              = "(#{@experience.reviews.length}件)"
+          %li.tab_2line
+            %span
+              写真
+            %br/
+            %span.number
+              (107枚)
+          %li.tab
+            %span
+              地図
+          %li.tab
+            %span
+              周辺情報
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -102,14 +102,24 @@
               %li.list_title
                 評価分布
               - 5.times do |i|
-                %li.list_score
-                  %span.evaluation
-                    = @evalutions[4 - i]
-                  %span{id: "score_#{5 - i}", class: 'persent'}
-                    = "#{(@scores.count(5 - i).to_f / @scores.length * 100).floor}%"
-                  .persent_graph
-                    %div{id: "graph_score#{5 - i}", class: 'persent_graph_front'}
-                    .persent_graph_back
+                - if @scores.length != 0
+                  %li.list_score
+                    %span.evaluation
+                      = @evalutions[4 - i]
+                    %span{id: "score_#{5 - i}", class: 'persent'}
+                      = "#{(@scores.count(5 - i).to_f / @scores.length * 100).floor}%"
+                    .persent_graph
+                      %div{id: "graph_score#{5 - i}", class: 'persent_graph_front'}
+                      .persent_graph_back
+                - else
+                  %li.list_score
+                    %span.evaluation
+                      = @evalutions[4 - i]
+                    %span{id: "score_#{5 - i}", class: 'persent'}
+                      0%
+                    .persent_graph
+                      %div{id: "graph_score#{5 - i}", class: 'persent_graph_front'}
+                      .persent_graph_back
         .business_info
           .business_info_title
             %span

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -33,6 +33,17 @@
             = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", '#', class: 'review_count review_link'
             %span.review_count
               ）
+          %li.black
+          %li.area_wrapper
+            %span.area
+              エリア
+            = link_to "#{@experience.area.island.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.area.name}",'#', id: 'change_link', class: 'link_to'
+          %li.genre_wrapper
+            %span.genre
+              ジャンル
+            = link_to "#{@experience.genre.category.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.genre.name}",'#', id: 'change_link', class: 'link_to'
       .show_info_right
         %ul
           %li.post_reviews

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -105,7 +105,7 @@
                 %span.evaluation
                   満足
                 %span{id: 'score_5', class: 'persent'}
-                  55%
+                  = "#{(@scores.count(5)/@scores.length.to_f * 100).floor}%"
                 .persent_graph
                   %div{id: 'graph_score5', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -113,7 +113,7 @@
                 %span.evaluation
                   やや満足
                 %span{id: 'score_4', class: 'persent'}
-                  34%
+                  = "#{(@scores.count(4)/@scores.length.to_f * 100).floor}%"
                 .persent_graph
                   %div{id: 'graph_score4', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -121,7 +121,7 @@
                 %span.evaluation
                   普通
                 %span{id: 'score_3', class: 'persent'}
-                  9%
+                  = "#{(@scores.count(3)/@scores.length.to_f * 100).floor}%"
                 .persent_graph
                   %div{id: 'graph_score3', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -129,7 +129,7 @@
                 %span.evaluation
                   やや不満
                 %span{id: 'score_2', class: 'persent'}
-                  1%
+                  = "#{(@scores.count(2)/@scores.length.to_f * 100).floor}%"
                 .persent_graph
                   %div{id: 'graph_score2', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -137,7 +137,7 @@
                 %span.evaluation
                   不満
                 %span{id: 'score_1', class: 'persent'}
-                  0%
+                  = "#{(@scores.count(1)/@scores.length.to_f * 100).floor}%"
                 .persent_graph
                   %div{id: 'graph_score1', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -158,7 +158,6 @@
             %span.business_info_main_address
             %span
   .show_content_right
-    - @experience.reviews.each do |review|
-      = review.score
+    
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -98,6 +98,49 @@
         %ul.picture_score
           .content_picture
           .content_score
+            %ul.content_score_list
+              %li.list_title
+                評価分布
+              %li.list_score
+                %span.evaluation
+                  満足
+                %span.persent
+                  55%
+                .persent_graph
+                  .persent_graph_front
+                  .persent_graph_back
+              %li.list_score
+                %span.evaluation
+                  やや満足
+                %span.persent
+                  34%
+                .persent_graph
+                  .persent_graph_front
+                  .persent_graph_back
+              %li.list_score
+                %span.evaluation
+                  普通
+                %span.persent
+                  9%
+                .persent_graph
+                  .persent_graph_front
+                  .persent_graph_back
+              %li.list_score
+                %span.evaluation
+                  やや不満
+                %span.persent
+                  1%
+                .persent_graph
+                  .persent_graph_front
+                  .persent_graph_back
+              %li.list_score
+                %span.evaluation
+                  不満
+                %span.persent
+                  0%
+                .persent_graph
+                  .persent_graph_front
+                  .persent_graph_back
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -1,13 +1,17 @@
 .header
   = render 'shared/leh_header'
 .show_content_area
-.content_header
-.menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
-  %span
-    &nbsp;>&nbsp;
-  %strong
-    -# = @category.name
+  .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
+    = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+    %span
+      &nbsp;>&nbsp;
+    = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
+    %span
+      &nbsp;>&nbsp;
+    %strong
+      = @experience.name
+    %span{id: 'category_id', style: 'display:none'}
+      = @experience.genre.category.id
 %h1
   = "#{@experience.name}の詳細"
   -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -70,6 +70,14 @@
             = link_to '', '#', class: 'btn'
     .show_left_main
       .show_left_main_tab
+        %ul.experience_tabs
+          %li.tab1
+          %li.tab2
+          %li.tab3
+          %li.tab4
+          %li.tab5
+          %li.tab6
+          %li.tab7
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -104,42 +104,42 @@
               %li.list_score
                 %span.evaluation
                   満足
-                %span.persent
+                %span{id: 'score_5', class: 'persent'}
                   55%
                 .persent_graph
-                  .persent_graph_front
+                  %div{id: 'graph_score5', class: 'persent_graph_front'}
                   .persent_graph_back
               %li.list_score
                 %span.evaluation
                   やや満足
-                %span.persent
+                %span{id: 'score_4', class: 'persent'}
                   34%
                 .persent_graph
-                  .persent_graph_front
+                  %div{id: 'graph_score4', class: 'persent_graph_front'}
                   .persent_graph_back
               %li.list_score
                 %span.evaluation
                   普通
-                %span.persent
+                %span{id: 'score_3', class: 'persent'}
                   9%
                 .persent_graph
-                  .persent_graph_front
+                  %div{id: 'graph_score3', class: 'persent_graph_front'}
                   .persent_graph_back
               %li.list_score
                 %span.evaluation
                   やや不満
-                %span.persent
+                %span{id: 'score_2', class: 'persent'}
                   1%
                 .persent_graph
-                  .persent_graph_front
+                  %div{id: 'graph_score2', class: 'persent_graph_front'}
                   .persent_graph_back
               %li.list_score
                 %span.evaluation
                   不満
-                %span.persent
+                %span{id: 'score_1', class: 'persent'}
                   0%
                 .persent_graph
-                  .persent_graph_front
+                  %div{id: 'graph_score1', class: 'persent_graph_front'}
                   .persent_graph_back
         .business_info
           .business_info_title
@@ -156,9 +156,7 @@
             %span.business_info_main_postalcode
               = @experience.address
             %span.business_info_main_address
-              -# 兵庫県西宮市甲子園8-1-100
             %span
-              -# ららぽーと甲子園
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -97,7 +97,9 @@
           = @experience.name
         .picture_score
           .content_picture
+            画像表示部分
           .content_score
+            -# アクティビティの5段階評価の各点数ごとの割合を表示させる。
             %ul.content_score_list
               %li.list_title
                 評価分布

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -158,5 +158,7 @@
             %span.business_info_main_address
             %span
   .show_content_right
+    - @experience.reviews.each do |review|
+      = review.score.id
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -16,13 +16,24 @@
     .show_left_info
       .show_info_left
       .show_info_right
+        %ul
+          %li.post_reviews
+            = icon('far', 'comment-dots', class: 'fa-flip-horizontal')
+            口コミ投稿
+          %li.share_act
+            = icon('fas', 'share')
+            シェアする
+        %ul.show_info_right_down
+          %li.favorite
+            -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。
+            - if @experience.already_favorited?(current_user)
+              = link_to icon("fas", "star"), experience_favorites_path(@experience.id), method: :delete
+            - else
+              = link_to icon("far", "star"), experience_favorites_path(@experience.id), method: :post
+            = @experience.favorites.length.to_s(:delimited)
+          %li.have_been_place
+            = icon('fas', 'shoe-prints',class: 'fa-rotate-270')
+            行った
   .show_content_right
-%h1
-  = "#{@experience.name}の詳細"
-  -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。
-  - if @experience.already_favorited?(current_user)
-    = link_to icon("fas", "star"), experience_favorites_path(@experience.id), method: :delete
-  - else
-    = link_to icon("far", "star"), experience_favorites_path(@experience.id), method: :post
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -1,5 +1,13 @@
 .header
   = render 'shared/leh_header'
+.show_content_area
+.content_header
+.menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
+  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+  %span
+    &nbsp;>&nbsp;
+  %strong
+    -# = @category.name
 %h1
   = "#{@experience.name}の詳細"
   -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。
@@ -7,3 +15,5 @@
     = link_to icon("fas", "star"), experience_favorites_path(@experience.id), method: :delete
   - else
     = link_to icon("far", "star"), experience_favorites_path(@experience.id), method: :post
+.footer
+  = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -159,6 +159,6 @@
             %span
   .show_content_right
     - @experience.reviews.each do |review|
-      = review.score.id
+      = review.score
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -19,7 +19,7 @@
           %li.show_info_name
             = image_tag 'shopping_icon.png', alt: '', height: '35px', width: '35px', class: ''
             %h1.experience_name
-              キッザニア甲子園
+              = @experience.name
           %li.show_info_score
             .star_rating
               %div{id: "star_rating0", class: 'star_rating_front'}
@@ -85,13 +85,19 @@
               写真
             %br/
             %span.number
-              (107枚)
+              (0枚)
           %li.tab
             %span
               地図
           %li.tab
             %span
               周辺情報
+      .show_left_main_content
+        %h1.experience_name
+          = @experience.name
+        %ul.picture_score
+          .content_picture
+          .content_score
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -141,19 +141,24 @@
                 .persent_graph
                   .persent_graph_front
                   .persent_graph_back
-        .dq
         .business_info
+          .business_info_title
+            %span
+              営業時間
+          .business_info_main
+            %span
+              = "平日: #{@experience.business_hours_start} 〜 #{@experience.business_hours_finish}"
         .business_info2
           .business_info_title
             %span
               所在地
           .business_info_main
             %span.business_info_main_postalcode
-              〒663-8178
+              = @experience.address
             %span.business_info_main_address
-              兵庫県西宮市甲子園8-1-100
+              -# 兵庫県西宮市甲子園8-1-100
             %span
-              ららぽーと甲子園
+              -# ららぽーと甲子園
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -71,7 +71,9 @@
     .show_left_main
       .show_left_main_tab
         %ul.experience_tabs
-          %li.tab1
+          %li{class: 'tab1 active_tab'}
+            %span
+              概要
           %li.tab2
           %li.tab3
           %li.tab4

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -22,7 +22,7 @@
               キッザニア甲子園
           %li.show_info_score
             .star_rating
-              %div{id: "star_rating", class: 'star_rating_front'}
+              %div{id: "star_rating0", class: 'star_rating_front'}
                 ★★★★★
               .star_rating_back
                 ★★★★★

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -1,17 +1,20 @@
 .header
   = render 'shared/leh_header'
-.show_content_area
-  .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-    = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
-    %span
-      &nbsp;>&nbsp;
-    = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
-    %span
-      &nbsp;>&nbsp;
-    %strong
-      = @experience.name
-    %span{id: 'category_id', style: 'display:none'}
-      = @experience.genre.category.id
+.menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
+  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+  %span
+    &nbsp;>&nbsp;
+  = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
+  %span
+    &nbsp;>&nbsp;
+  %strong
+    = @experience.name
+  %span{id: 'category_id', style: 'display:none'}
+    = @experience.genre.category.id
+.show_content_wrapper
+  .show_content_left
+    .show_left_info
+  .show_content_right
 %h1
   = "#{@experience.name}の詳細"
   -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -15,6 +15,24 @@
   .show_content_left
     .show_left_info
       .show_info_left
+        %ul
+          %li.show_info_name
+            = image_tag 'shopping_icon.png', alt: '', height: '35px', width: '35px', class: ''
+            %h1.experience_name
+              キッザニア甲子園
+          %li.show_info_score
+            .star_rating
+              %div{id: "star_rating", class: 'star_rating_front'}
+                ★★★★★
+              .star_rating_back
+                ★★★★★
+            %span{class: 'rating_point exp_score'}
+              = @experience.score
+            %span.review_count
+              （
+            = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", '#', class: 'review_count review_link'
+            %span.review_count
+              ）
       .show_info_right
         %ul
           %li.post_reviews

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -20,20 +20,25 @@
           %li.post_reviews
             = icon('far', 'comment-dots', class: 'fa-flip-horizontal')
             口コミ投稿
+            = link_to '','#', class: 'btn'
           %li.share_act
             = icon('fas', 'share')
             シェアする
+            = link_to '','#', class: 'btn'
         %ul.show_info_right_down
           %li.favorite
             -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。
             - if @experience.already_favorited?(current_user)
-              = link_to icon("fas", "star"), experience_favorites_path(@experience.id), method: :delete
+              = icon("fas", "star")
+              = link_to '', experience_favorites_path(@experience.id), method: :delete, class: 'btn'
             - else
-              = link_to icon("far", "star"), experience_favorites_path(@experience.id), method: :post
+              = icon("far", "star")
+              = link_to '', experience_favorites_path(@experience.id), method: :post, class: 'btn'
             = @experience.favorites.length.to_s(:delimited)
           %li.have_been_place
             = icon('fas', 'shoe-prints',class: 'fa-rotate-270')
             行った
+            = link_to '', '#', class: 'btn'
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -105,7 +105,7 @@
                 %span.evaluation
                   満足
                 %span{id: 'score_5', class: 'persent'}
-                  = "#{(@scores.count(5)/@scores.length.to_f * 100).floor}%"
+                  = "#{(@scores.count(5).to_f/@scores.length * 100).to_i}%"
                 .persent_graph
                   %div{id: 'graph_score5', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -113,7 +113,7 @@
                 %span.evaluation
                   やや満足
                 %span{id: 'score_4', class: 'persent'}
-                  = "#{(@scores.count(4)/@scores.length.to_f * 100).floor}%"
+                  = "#{(@scores.count(4).to_f/@scores.length * 100).to_i}%"
                 .persent_graph
                   %div{id: 'graph_score4', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -121,7 +121,7 @@
                 %span.evaluation
                   普通
                 %span{id: 'score_3', class: 'persent'}
-                  = "#{(@scores.count(3)/@scores.length.to_f * 100).floor}%"
+                  = "#{(@scores.count(3).to_f/@scores.length * 100).to_i}%"
                 .persent_graph
                   %div{id: 'graph_score3', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -129,7 +129,7 @@
                 %span.evaluation
                   やや不満
                 %span{id: 'score_2', class: 'persent'}
-                  = "#{(@scores.count(2)/@scores.length.to_f * 100).floor}%"
+                  = "#{(@scores.count(2).to_f/@scores.length.to_f * 100).to_i}%"
                 .persent_graph
                   %div{id: 'graph_score2', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -137,7 +137,7 @@
                 %span.evaluation
                   不満
                 %span{id: 'score_1', class: 'persent'}
-                  = "#{(@scores.count(1)/@scores.length.to_f * 100).floor}%"
+                  = "#{(@scores.count(1)/@scores.length.to_f * 100).to_i}%"
                 .persent_graph
                   %div{id: 'graph_score1', class: 'persent_graph_front'}
                   .persent_graph_back
@@ -158,6 +158,5 @@
             %span.business_info_main_address
             %span
   .show_content_right
-    
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -95,7 +95,7 @@
       .show_left_main_content
         %h1.experience_name
           = @experience.name
-        %ul.picture_score
+        .picture_score
           .content_picture
           .content_score
             %ul.content_score_list
@@ -141,6 +141,19 @@
                 .persent_graph
                   .persent_graph_front
                   .persent_graph_back
+        .dq
+        .business_info
+        .business_info2
+          .business_info_title
+            %span
+              所在地
+          .business_info_main
+            %span.business_info_main_postalcode
+              〒663-8178
+            %span.business_info_main_address
+              兵庫県西宮市甲子園8-1-100
+            %span
+              ららぽーと甲子園
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -101,46 +101,15 @@
             %ul.content_score_list
               %li.list_title
                 評価分布
-              %li.list_score
-                %span.evaluation
-                  満足
-                %span{id: 'score_5', class: 'persent'}
-                  = "#{(@scores.count(5).to_f/@scores.length * 100).to_i}%"
-                .persent_graph
-                  %div{id: 'graph_score5', class: 'persent_graph_front'}
-                  .persent_graph_back
-              %li.list_score
-                %span.evaluation
-                  やや満足
-                %span{id: 'score_4', class: 'persent'}
-                  = "#{(@scores.count(4).to_f/@scores.length * 100).to_i}%"
-                .persent_graph
-                  %div{id: 'graph_score4', class: 'persent_graph_front'}
-                  .persent_graph_back
-              %li.list_score
-                %span.evaluation
-                  普通
-                %span{id: 'score_3', class: 'persent'}
-                  = "#{(@scores.count(3).to_f/@scores.length * 100).to_i}%"
-                .persent_graph
-                  %div{id: 'graph_score3', class: 'persent_graph_front'}
-                  .persent_graph_back
-              %li.list_score
-                %span.evaluation
-                  やや不満
-                %span{id: 'score_2', class: 'persent'}
-                  = "#{(@scores.count(2).to_f/@scores.length.to_f * 100).to_i}%"
-                .persent_graph
-                  %div{id: 'graph_score2', class: 'persent_graph_front'}
-                  .persent_graph_back
-              %li.list_score
-                %span.evaluation
-                  不満
-                %span{id: 'score_1', class: 'persent'}
-                  = "#{(@scores.count(1)/@scores.length.to_f * 100).to_i}%"
-                .persent_graph
-                  %div{id: 'graph_score1', class: 'persent_graph_front'}
-                  .persent_graph_back
+              - 5.times do |i|
+                %li.list_score
+                  %span.evaluation
+                    = @evalutions[4 - i]
+                  %span{id: "score_#{5 - i}", class: 'persent'}
+                    = "#{(@scores.count(5 - i).to_f / @scores.length * 100).floor}%"
+                  .persent_graph
+                    %div{id: "graph_score#{5 - i}", class: 'persent_graph_front'}
+                    .persent_graph_back
         .business_info
           .business_info_title
             %span

--- a/db/migrate/20201111140357_rename_score_id_column_to_reviews.rb
+++ b/db/migrate/20201111140357_rename_score_id_column_to_reviews.rb
@@ -1,0 +1,5 @@
+class RenameScoreIdColumnToReviews < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :reviews, :score_id, :score
+  end
+end

--- a/db/migrate/20201111140357_rename_score_id_column_to_reviews.rb
+++ b/db/migrate/20201111140357_rename_score_id_column_to_reviews.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameScoreIdColumnToReviews < ActiveRecord::Migration[6.0]
   def change
     rename_column :reviews, :score_id, :score

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,121 +12,120 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_140357) do
-
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+ActiveRecord::Schema.define(version: 20_201_111_140_357) do
+  create_table 'active_storage_attachments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', null: false
+    t.string 'record_type', null: false
+    t.bigint 'record_id', null: false
+    t.bigint 'blob_id', null: false
+    t.datetime 'created_at', null: false
+    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
+    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  create_table 'active_storage_blobs', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'key', null: false
+    t.string 'filename', null: false
+    t.string 'content_type'
+    t.text 'metadata'
+    t.bigint 'byte_size', null: false
+    t.string 'checksum', null: false
+    t.datetime 'created_at', null: false
+    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
   end
 
-  create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.integer "island_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+  create_table 'areas', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', default: '', null: false
+    t.integer 'island_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
   end
 
-  create_table "experiences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.text "outline"
-    t.string "address", null: false
-    t.float "latitude", limit: 53, null: false
-    t.float "longitude", limit: 53, null: false
-    t.string "business_hours_start"
-    t.string "business_hours_finish"
-    t.bigint "area_id", null: false
-    t.bigint "genre_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.float "score"
-    t.index ["area_id"], name: "index_experiences_on_area_id"
-    t.index ["genre_id"], name: "index_experiences_on_genre_id"
+  create_table 'experiences', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', default: '', null: false
+    t.text 'outline'
+    t.string 'address', null: false
+    t.float 'latitude', limit: 53, null: false
+    t.float 'longitude', limit: 53, null: false
+    t.string 'business_hours_start'
+    t.string 'business_hours_finish'
+    t.bigint 'area_id', null: false
+    t.bigint 'genre_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.float 'score'
+    t.index ['area_id'], name: 'index_experiences_on_area_id'
+    t.index ['genre_id'], name: 'index_experiences_on_genre_id'
   end
 
-  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "experience_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["experience_id"], name: "index_favorites_on_experience_id"
-    t.index ["user_id"], name: "index_favorites_on_user_id"
+  create_table 'favorites', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'experience_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['experience_id'], name: 'index_favorites_on_experience_id'
+    t.index ['user_id'], name: 'index_favorites_on_user_id'
   end
 
-  create_table "genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "category_id", null: false
+  create_table 'genres', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', default: '', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'category_id', null: false
   end
 
-  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "experience_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["experience_id"], name: "index_histories_on_experience_id"
-    t.index ["user_id"], name: "index_histories_on_user_id"
+  create_table 'histories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'experience_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['experience_id'], name: 'index_histories_on_experience_id'
+    t.index ['user_id'], name: 'index_histories_on_user_id'
   end
 
-  create_table "reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "comment", null: false
-    t.integer "score", null: false
-    t.bigint "user_id", null: false
-    t.bigint "experience_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["experience_id"], name: "index_reviews_on_experience_id"
-    t.index ["user_id"], name: "index_reviews_on_user_id"
+  create_table 'reviews', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.text 'comment', null: false
+    t.integer 'score', null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'experience_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['experience_id'], name: 'index_reviews_on_experience_id'
+    t.index ['user_id'], name: 'index_reviews_on_user_id'
   end
 
-  create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "provider"
-    t.string "uid"
-    t.bigint "user_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
+  create_table 'sns_credentials', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'provider'
+    t.string 'uid'
+    t.bigint 'user_id'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['user_id'], name: 'index_sns_credentials_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name", default: "", null: false
-    t.text "introduce"
-    t.integer "admin"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name', default: '', null: false
+    t.text 'introduce'
+    t.integer 'admin'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "experiences", "areas"
-  add_foreign_key "experiences", "genres"
-  add_foreign_key "favorites", "experiences"
-  add_foreign_key "favorites", "users"
-  add_foreign_key "histories", "experiences"
-  add_foreign_key "histories", "users"
-  add_foreign_key "reviews", "experiences"
-  add_foreign_key "reviews", "users"
-  add_foreign_key "sns_credentials", "users"
+  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
+  add_foreign_key 'experiences', 'areas'
+  add_foreign_key 'experiences', 'genres'
+  add_foreign_key 'favorites', 'experiences'
+  add_foreign_key 'favorites', 'users'
+  add_foreign_key 'histories', 'experiences'
+  add_foreign_key 'histories', 'users'
+  add_foreign_key 'reviews', 'experiences'
+  add_foreign_key 'reviews', 'users'
+  add_foreign_key 'sns_credentials', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,120 +10,121 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_201_103_123_618) do
-  create_table 'active_storage_attachments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
+ActiveRecord::Schema.define(version: 2020_11_11_140357) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table 'active_storage_blobs', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.bigint 'byte_size', null: false
-    t.string 'checksum', null: false
-    t.datetime 'created_at', null: false
-    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'areas', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name', default: '', null: false
-    t.integer 'island_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.integer "island_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'experiences', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name', default: '', null: false
-    t.text 'outline'
-    t.string 'address', null: false
-    t.float 'latitude', limit: 53, null: false
-    t.float 'longitude', limit: 53, null: false
-    t.string 'business_hours_start'
-    t.string 'business_hours_finish'
-    t.bigint 'area_id', null: false
-    t.bigint 'genre_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.float 'score'
-    t.index ['area_id'], name: 'index_experiences_on_area_id'
-    t.index ['genre_id'], name: 'index_experiences_on_genre_id'
+  create_table "experiences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.text "outline"
+    t.string "address", null: false
+    t.float "latitude", limit: 53, null: false
+    t.float "longitude", limit: 53, null: false
+    t.string "business_hours_start"
+    t.string "business_hours_finish"
+    t.bigint "area_id", null: false
+    t.bigint "genre_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.float "score"
+    t.index ["area_id"], name: "index_experiences_on_area_id"
+    t.index ["genre_id"], name: "index_experiences_on_genre_id"
   end
 
-  create_table 'favorites', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'experience_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['experience_id'], name: 'index_favorites_on_experience_id'
-    t.index ['user_id'], name: 'index_favorites_on_user_id'
+  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "experience_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["experience_id"], name: "index_favorites_on_experience_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
-  create_table 'genres', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name', default: '', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'category_id', null: false
+  create_table "genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "category_id", null: false
   end
 
-  create_table 'histories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'experience_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['experience_id'], name: 'index_histories_on_experience_id'
-    t.index ['user_id'], name: 'index_histories_on_user_id'
+  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "experience_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["experience_id"], name: "index_histories_on_experience_id"
+    t.index ["user_id"], name: "index_histories_on_user_id"
   end
 
-  create_table 'reviews', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.text 'comment', null: false
-    t.integer 'score_id', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'experience_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['experience_id'], name: 'index_reviews_on_experience_id'
-    t.index ['user_id'], name: 'index_reviews_on_user_id'
+  create_table "reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "comment", null: false
+    t.integer "score", null: false
+    t.bigint "user_id", null: false
+    t.bigint "experience_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["experience_id"], name: "index_reviews_on_experience_id"
+    t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
-  create_table 'sns_credentials', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'provider'
-    t.string 'uid'
-    t.bigint 'user_id'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['user_id'], name: 'index_sns_credentials_on_user_id'
+  create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', default: '', null: false
-    t.text 'introduce'
-    t.integer 'admin'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", default: "", null: false
+    t.text "introduce"
+    t.integer "admin"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'experiences', 'areas'
-  add_foreign_key 'experiences', 'genres'
-  add_foreign_key 'favorites', 'experiences'
-  add_foreign_key 'favorites', 'users'
-  add_foreign_key 'histories', 'experiences'
-  add_foreign_key 'histories', 'users'
-  add_foreign_key 'reviews', 'experiences'
-  add_foreign_key 'reviews', 'users'
-  add_foreign_key 'sns_credentials', 'users'
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "experiences", "areas"
+  add_foreign_key "experiences", "genres"
+  add_foreign_key "favorites", "experiences"
+  add_foreign_key "favorites", "users"
+  add_foreign_key "histories", "experiences"
+  add_foreign_key "histories", "users"
+  add_foreign_key "reviews", "experiences"
+  add_foreign_key "reviews", "users"
+  add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
## 概要
* `アクティビティ詳細表示ページ`が初期の状態となっているので、ユーザーが見やすい様にビューファイルを調整する。

## 変更点
* アクティビティ毎の評価点や所在地等を見られる様に`@experience`と`@scores`インスタンスをビューファイルに受渡し、情報を表示させる。

## テスト結果とテスト項目
- [x] アクティビティ毎に、5段階評価の評価分布がパーセントで表示され、グラフが表示されている。
- [x] アクティビティ毎に所在地・営業時間や評価点が表示されている。

## Issue番号
close #45 