### PR TITLE
アクティビティの口コミ一覧表示実装

### DIFF
--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -14,6 +14,7 @@ $colorBlack: #333333;
 .show_content_wrapper{
   @extend .menu;
   display: flex;
+  margin-bottom: 30px;
   .show_content_left{
     width: $contentLeftWidth;
     margin-right: $contentLeftMargin;
@@ -251,7 +252,6 @@ $colorBlack: #333333;
         .business_info2{
           @extend .business_info;
           border-top: 0;
-          margin-bottom: 30px;
         }
       }
     }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -128,6 +128,14 @@ $colorBlack: #333333;
             line-height: 15px;
             text-align: center;
             cursor: pointer;
+            position: relative;
+            .exp_link{
+              position: absolute;
+              top: 0;
+              left: 0;
+              height: 100%;
+              width: 100%;
+            }
             .number{
               font-size: 11px;
             }
@@ -143,12 +151,8 @@ $colorBlack: #333333;
             @extend .tab;
             position: relative;
             padding: 6px 0 0;
-            .reviews_index{
-              position: absolute;
-              top: 0;
-              left: 0;
-              height: 100%;
-              width: 100%;
+            .exp_link{
+              @extend .exp_link;
             }
           }
         }

--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -141,7 +141,15 @@ $colorBlack: #333333;
           }
           .tab_2line{
             @extend .tab;
+            position: relative;
             padding: 6px 0 0;
+            .reviews_index{
+              position: absolute;
+              top: 0;
+              left: 0;
+              height: 100%;
+              width: 100%;
+            }
           }
         }
       }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -377,3 +377,7 @@
     }
   }
 }
+.not_review_index_content{
+  @extend .review_index_content;
+  height: calc(100vh - 489px);
+}

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -15,6 +15,12 @@
   color: #ffffff;
   background-color: #ff4500;
 }
+@mixin titleIcon {
+  height: 22px;
+  width: 5px;
+  border-radius: 2px;
+  background-color: #ff4500;
+}
 .review_new_wrapper{
   width: 950px;
   margin: 0 auto 100px;
@@ -28,10 +34,7 @@
       &_title{
         display: flex;
         .head_icon{
-          height: 22px;
-          width: 5px;
-          border-radius: 2px;
-          background-color: #ff4500;
+          @include titleIcon();
         }
         .head_name{
           font-size: 18px;
@@ -114,10 +117,9 @@
         .review_title_info{
           display: flex;
           .title_icon{
+            @include titleIcon();
             height: 15px;
-            width: 4px;
             border-radius: 1px;
-            background-color: #ff4500;
           }
           .title_name{
             font-size: 14px;
@@ -269,5 +271,59 @@
     height: 1000px;
     width: 180px;
     // background-color: black;
+  }
+}
+.review_index_content{
+  @extend .show_left_main_content;
+  height: 1000px;
+  .review_index_title_area{
+    display: flex;
+    .review_index_title_icon{
+      @include titleIcon();
+      margin: 1px 5px 0 0;
+    }
+    .review_index_title{
+      @extend .experience_name;
+    }
+  }
+  .review_index_info{
+    display: flex;
+    justify-content: space-between;
+    word-spacing: 0;
+    color: $colorBlack;
+    border-bottom: 3px solid #eee;
+    padding-bottom: 6px;
+    .review_number{
+      display: flex;
+      .review_number_part{
+        font-size: 16px;
+      }
+      .review_number_all{
+        font-size: 12px;
+        margin: 4px 0 0 5px;
+      }
+    }
+    .review_sort{
+      display: flex;
+      font-size: 12px;
+      margin: 2px 64px 0 0;
+      li{
+        height: 12px;
+        line-height: 12px;
+        border-right: 1px solid $gray;
+        padding: 0 5px;
+      }
+      .sort_link{
+        color: #0000ff;
+        text-decoration: underline;
+        cursor: pointer;
+        &.active_sort{
+          color: #000000;
+          font-weight: bold;
+          text-decoration: none;
+          cursor: auto;
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -327,7 +327,6 @@
   .review_index_main_wrapper{
     border-bottom: 3px solid #eee;
     padding: 12px 0 15px;
-    margin-bottom: 30px;
     color: $colorBlack;
     .review_index_main_area{
       width: 99%;

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -331,7 +331,6 @@
       height: 300px;
       width: 99%;
       margin: 0 auto;
-      // background-color: $gray;
       .review_index_title{
         font-size: 14px;
         font-weight: bold;
@@ -359,6 +358,20 @@
         .review_index_comment{
           color: $colorBlack;
           font-size: 12px;
+        }
+      }
+      .review_index_user_area{
+        display: flex;
+        margin-top: 10px;
+        .review_index_user_image{
+          height: 30px;
+          width: 30px;
+          margin-right: 9px;
+          background-color: $gray;
+        }
+        .review_index_user_name{
+          font-size: 11px;
+          line-height: 32px;
         }
       }
     }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -21,6 +21,10 @@
   border-radius: 2px;
   background-color: #ff4500;
 }
+@keyframes fadeIn {
+  0% {opacity: 0;}
+  100% {opacity: 1;}
+}
 .review_new_wrapper{
   width: 950px;
   margin: 0 auto 100px;
@@ -324,53 +328,57 @@
       }
     }
   }
-  .review_index_main_wrapper{
-    border-bottom: 3px solid #eee;
-    padding: 12px 0 15px;
-    color: $colorBlack;
-    .review_index_main_area{
-      width: 99%;
-      margin: 0 auto;
-      .review_index_title{
-        font-size: 14px;
-        font-weight: bold;
-        color: #0000ff;
-        text-decoration: underline;
-      }
-      .review_index_score{
-        margin-top: 2px;
-        @include expScore;
-        .rating_point{
-          font-size: 16px;
+  .review_list{
+    &.active_fade{
+      animation: fadeIn 0.5s;
+    }
+    .review_index_main_wrapper{
+      border-bottom: 3px solid #eee;
+      padding: 12px 0 15px;
+      color: $colorBlack;
+      .review_index_main_area{
+        width: 99%;
+        margin: 0 auto;
+        .review_index_title{
+          font-size: 14px;
+          font-weight: bold;
+          color: #0000ff;
+          text-decoration: underline;
         }
-      }
-      .triangle{
-        color: #eee;
-        margin: -5px 0 0 27px;
-        font-size: 14px;
-      }
-      .review_index_comment_area{
-        margin-top: -7px;
-        padding: 8px;
-        border-radius: 6px;
-        background-color: #eee;
-        .review_index_comment{
-          // font-size: 12px;
-          font-size: 20px;
+        .review_index_score{
+          margin-top: 2px;
+          @include expScore;
+          .rating_point{
+            font-size: 16px;
+          }
         }
-      }
-      .review_index_user_area{
-        display: flex;
-        margin-top: 10px;
-        .user_image{
-          height: 30px;
-          width: 30px;
-          margin-right: 9px;
-          background-color: $gray;
+        .triangle{
+          color: #eee;
+          margin: -5px 0 0 27px;
+          font-size: 14px;
         }
-        .review_index_user_name{
-          font-size: 11px;
-          line-height: 32px;
+        .review_index_comment_area{
+          margin-top: -7px;
+          padding: 8px;
+          border-radius: 6px;
+          background-color: #eee;
+          .review_index_comment{
+            font-size: 20px;
+          }
+        }
+        .review_index_user_area{
+          display: flex;
+          margin-top: 10px;
+          .user_image{
+            height: 30px;
+            width: 30px;
+            margin-right: 9px;
+            background-color: $gray;
+          }
+          .review_index_user_name{
+            font-size: 11px;
+            line-height: 32px;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -346,6 +346,21 @@
           font-size: 16px;
         }
       }
+      .triangle{
+        color: #eee;
+        margin: -5px 0 0 27px;
+        font-size: 14px;
+      }
+      .review_index_comment_area{
+        margin-top: -7px;
+        padding: 8px;
+        border-radius: 6px;
+        background-color: #eee;
+        .review_index_comment{
+          color: $colorBlack;
+          font-size: 12px;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -274,7 +274,6 @@
 }
 .review_index_content{
   @extend .show_left_main_content;
-  height: 1000px;
   .review_index_title_area{
     display: flex;
     .review_index_title_icon{
@@ -326,9 +325,11 @@
     }
   }
   .review_index_main_wrapper{
-    height: 500px;
+    border-bottom: 3px solid #eee;
+    padding: 12px 0 15px;
+    margin-bottom: 30px;
+    color: $colorBlack;
     .review_index_main_area{
-      height: 300px;
       width: 99%;
       margin: 0 auto;
       .review_index_title{
@@ -336,7 +337,6 @@
         font-weight: bold;
         color: #0000ff;
         text-decoration: underline;
-        margin-top: 12px;
       }
       .review_index_score{
         margin-top: 2px;
@@ -356,7 +356,6 @@
         border-radius: 6px;
         background-color: #eee;
         .review_index_comment{
-          color: $colorBlack;
           font-size: 12px;
         }
       }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -270,7 +270,6 @@
   .review_old_show{
     height: 1000px;
     width: 180px;
-    // background-color: black;
   }
 }
 .review_index_content{
@@ -323,6 +322,22 @@
           text-decoration: none;
           cursor: auto;
         }
+      }
+    }
+  }
+  .review_index_main_wrapper{
+    height: 500px;
+    .review_index_main_area{
+      height: 300px;
+      width: 99%;
+      margin: 0 auto;
+      // background-color: $gray;
+      .review_index_title{
+        font-size: 14px;
+        font-weight: bold;
+        color: #0000ff;
+        text-decoration: underline;
+        margin-top: 12px;
       }
     }
   }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -339,6 +339,13 @@
         text-decoration: underline;
         margin-top: 12px;
       }
+      .review_index_score{
+        margin-top: 2px;
+        @include expScore;
+        .rating_point{
+          font-size: 16px;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -356,13 +356,14 @@
         border-radius: 6px;
         background-color: #eee;
         .review_index_comment{
-          font-size: 12px;
+          // font-size: 12px;
+          font-size: 20px;
         }
       }
       .review_index_user_area{
         display: flex;
         margin-top: 10px;
-        .review_index_user_image{
+        .user_image{
           height: 30px;
           width: 30px;
           margin-right: 9px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,11 @@ class ApplicationController < ActionController::Base
   def redirect_experience(experience_id)
     redirect_to "/experiences/#{experience_id}"
   end
+
+  def images_count(exp_id)
+    @images_count = 0
+    Review.where(experience_id: exp_id).find_each do |review|
+      @images_count += review.images.count
+    end
+  end
 end

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -7,7 +7,7 @@ class ExperiencesController < ApplicationController
     @experience = Experience.find(params[:id])
     # ハッシュ形式で各評価点がいくつあるかを格納する。
     @scores = @experience.reviews.group(:score).count
-    images_count(@experience)
+    images_count(@experience.id)
     @evalutions = %w[不満 やや不満 普通 やや満足 満足]
   end
 
@@ -21,12 +21,4 @@ class ExperiencesController < ApplicationController
     render 'experiences/category'
   end
 
-  private
-
-  def images_count(exp)
-    @images_count = 0
-    Review.where(experience_id: exp.id).find_each do |review|
-      @images_count += review.images.count
-    end
-  end
 end

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -20,5 +20,4 @@ class ExperiencesController < ApplicationController
     end
     render 'experiences/category'
   end
-
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -7,7 +7,7 @@ class ReviewsController < ApplicationController
   def index
     @reviews = Review.where(experience_id: params[:experience_id])
     images_count(params[:experience_id])
-    binding.pry
+    # binding.pry
   end
 
   def new

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
   before_action :find_experience, only: %i[index new create]
 
   def index
-    @reviews = Review.where(experience_id: params[:experience_id])
+    @reviews = Review.includes(:user).where(experience_id: params[:experience_id])
     images_count(params[:experience_id])
     # binding.pry
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
   before_action :find_experience, only: %i[index new create]
 
   def index
-    @reviews = Review.includes(:user).where(experience_id: params[:experience_id])
+    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order("created_at DESC")
     images_count(params[:experience_id])
     # binding.pry
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
   before_action :find_experience, only: %i[index new create]
 
   def index
-    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order("created_at DESC")
+    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order("score DESC")
     images_count(params[:experience_id])
     # binding.pry
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -2,12 +2,12 @@
 
 class ReviewsController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
-  before_action :find_experience, only: %i[new create]
+  before_action :find_experience, only: %i[index new create]
 
   def index
     @reviews = Review.where(experience_id: params[:experience_id])
-    find_experience
-    # binding.pry
+    images_count(params[:experience_id])
+    binding.pry
   end
 
   def new
@@ -19,8 +19,8 @@ class ReviewsController < ApplicationController
     if @review.valid?
       @review.save
       # 保存されている全口コミの評価点の平均を算出して、アクティビティの評価点を更新する。
-      find_experience.update(score: find_experience.reviews.average(:score).round(1))
-      redirect_to experience_path(params[:experience_id])
+      @experience.update(score: @experience.reviews.average(:score).round(1))
+      redirect_experience(params[:experience_id])
     else
       render action: :new
     end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
   before_action :find_experience, only: %i[index new create]
 
   def index
-    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order("score DESC")
+    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order("created_at DESC")
     images_count(params[:experience_id])
     # binding.pry
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,6 +4,12 @@ class ReviewsController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
   before_action :find_experience, only: %i[new create]
 
+  def index
+    @reviews = Review.where(experience_id: params[:experience_id])
+    find_experience
+    # binding.pry
+  end
+
   def new
     @review = Review.new
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
   before_action :find_experience, only: %i[index new create]
 
   def index
-    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order("created_at DESC")
+    @reviews = Review.includes(:user).where(experience_id: params[:experience_id]).order('created_at DESC')
     images_count(params[:experience_id])
     # binding.pry
   end

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -3,6 +3,7 @@
 $(function(){
 
   let clickedId = 0
+  let reviewList = null
 
   // '★'をクリックした位置から左側の'★'がホバーを外しても表示が変更されたままで、クリックした位置から右側が非選択状態になる。
   $('[id^="review_score_"]').on('click', function(){
@@ -28,13 +29,34 @@ $(function(){
     }
   });
 
+  // 並び替えの'評価順'ボタンをクリックすると、アクティビティの評価点の降順に表示を変更する。
   $('#sort_score').on('click', function(){
-    const reviewList = $('.review_list li');
+    reviewList = $('.review_list li');
     reviewList.sort(function(a,b){
       const aScore = Number($(a).find('.exp_score').text());
       const bScore = Number($(b).find('.exp_score').text());
       return bScore - aScore;
     });
+    $('#sort_created_at').removeClass('active_sort')
+    $('#sort_score').addClass('active_sort')
+    $('.review_list').empty();
+    $('.review_list').append(reviewList);
+  });
+  // 並び替えの'投稿日順'ボタンをクリックすると、アクティビティの投稿日の降順に表示を変更する。
+  $('#sort_created_at').on('click', function(){
+    reviewList = $('.review_list li');
+    reviewList.sort(function(a,b){
+      const aTime = $(a).find('.review_created_at').text();
+      const bTime = $(b).find('.review_created_at').text();
+      if (aTime > bTime) {
+        return -1
+      } else {
+        return 1
+      }
+    });
+    console.log(reviewList);
+    $('#sort_score').removeClass('active_sort')
+    $('#sort_created_at').addClass('active_sort')
     $('.review_list').empty();
     $('.review_list').append(reviewList);
   });

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -32,28 +32,31 @@ $(function(){
 
   // 並び替えの'評価順・投稿日順'ボタンをクリックすると、アクティビティの評価点・投稿日の降順に表示を変更する。
   $('[id^="review_sort_"]').on('click', function(){
-    const reviewSortId = this.id.match(/\d/)[0];
-    // 表示している口コミの要素一覧を変数に格納する。
-    const reviewList = $('.review_list li');
-    reviewList.sort(function(a,b){
-      const aText = $(a).find(`.review_sort_material${reviewSortId}`).text();
-      const bText = $(b).find(`.review_sort_material${reviewSortId}`).text();
-      if (aText > bText) {
-        return -1
-      } else {
-        return 1
-      }
-    });
-    $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort');
-    // 選択した並び順のID数値を再代入している。
-    activeReviewSortId = reviewSortId;
-    $(this).addClass('active_sort');
-    $('.review_list').empty();
-    $('.review_list').append(reviewList);
-    $('.review_list').addClass('active_fade');
-    setTimeout(function(){
-      $('.review_list').removeClass('active_fade');
-    }, 500);
+    const reviewSortId = Number(this.id.match(/\d/)[0]);
+    // すでに選択されている並び順では、動作しない様に否定文で分岐させる。
+    if (!(reviewSortId === activeReviewSortId)) {
+      // 表示している口コミの要素一覧を変数に格納する。
+      const reviewList = $('.review_list li');
+      reviewList.sort(function(a,b){
+        const aText = $(a).find(`.review_sort_material${reviewSortId}`).text();
+        const bText = $(b).find(`.review_sort_material${reviewSortId}`).text();
+        if (aText > bText) {
+          return -1
+        } else {
+          return 1
+        }
+      });
+      $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort');
+      // 選択した並び順のID数値を再代入している。
+      activeReviewSortId = reviewSortId;
+      $(this).addClass('active_sort');
+      $('.review_list').empty();
+      $('.review_list').append(reviewList);
+      $('.review_list').addClass('active_fade');
+      setTimeout(function(){
+        $('.review_list').removeClass('active_fade');
+      }, 500);
+    }
   });
 
 });

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -3,7 +3,8 @@
 $(function(){
 
   let clickedId = 0
-  let reviewList = null
+  // 口コミページ表示直後は投稿日順で表示されている為、2を変数に代入している。
+  let activeReviewSortId = 2
 
   // '★'をクリックした位置から左側の'★'がホバーを外しても表示が変更されたままで、クリックした位置から右側が非選択状態になる。
   $('[id^="review_score_"]').on('click', function(){
@@ -29,37 +30,24 @@ $(function(){
     }
   });
 
-  // 並び替えの'評価順'ボタンをクリックすると、アクティビティの評価点の降順に表示を変更する。
-  $('#sort_score').on('click', function(){
-    reviewList = $('.review_list li');
+  // 並び替えの'評価順・投稿日順'ボタンをクリックすると、アクティビティの評価点・投稿日の降順に表示を変更する。
+  $('[id^="review_sort_"]').on('click', function(){
+    const reviewSortId = this.id.match(/\d/)[0];
+    // 表示している口コミの要素一覧を変数に格納する。
+    const reviewList = $('.review_list li');
     reviewList.sort(function(a,b){
-      const aScore = Number($(a).find('.exp_score').text());
-      const bScore = Number($(b).find('.exp_score').text());
-      return bScore - aScore;
-    });
-    $('#sort_created_at').removeClass('active_sort')
-    $(this).addClass('active_sort') 
-    $('.review_list').empty();
-    $('.review_list').append(reviewList);
-    $('.review_list').addClass('active_fade');
-    setTimeout(function(){
-      $('.review_list').removeClass('active_fade');
-    }, 500);
-  });
-  // 並び替えの'投稿日順'ボタンをクリックすると、アクティビティの投稿日の降順に表示を変更する。
-  $('#sort_created_at').on('click', function(){
-    reviewList = $('.review_list li');
-    reviewList.sort(function(a,b){
-      const aTime = $(a).find('.review_created_at').text();
-      const bTime = $(b).find('.review_created_at').text();
-      if (aTime > bTime) {
+      const aText = $(a).find(`.review_sort_material${reviewSortId}`).text();
+      const bText = $(b).find(`.review_sort_material${reviewSortId}`).text();
+      if (aText > bText) {
         return -1
       } else {
         return 1
       }
     });
-    $('#sort_score').removeClass('active_sort')
-    $(this).addClass('active_sort')
+    $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort');
+    // 選択した並び順のID数値を再代入している。
+    activeReviewSortId = reviewSortId;
+    $(this).addClass('active_sort');
     $('.review_list').empty();
     $('.review_list').append(reviewList);
     $('.review_list').addClass('active_fade');

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -38,9 +38,13 @@ $(function(){
       return bScore - aScore;
     });
     $('#sort_created_at').removeClass('active_sort')
-    $('#sort_score').addClass('active_sort')
+    $(this).addClass('active_sort') 
     $('.review_list').empty();
     $('.review_list').append(reviewList);
+    $('.review_list').addClass('active_fade');
+    setTimeout(function(){
+      $('.review_list').removeClass('active_fade');
+    }, 500);
   });
   // 並び替えの'投稿日順'ボタンをクリックすると、アクティビティの投稿日の降順に表示を変更する。
   $('#sort_created_at').on('click', function(){
@@ -54,11 +58,14 @@ $(function(){
         return 1
       }
     });
-    console.log(reviewList);
     $('#sort_score').removeClass('active_sort')
-    $('#sort_created_at').addClass('active_sort')
+    $(this).addClass('active_sort')
     $('.review_list').empty();
     $('.review_list').append(reviewList);
+    $('.review_list').addClass('active_fade');
+    setTimeout(function(){
+      $('.review_list').removeClass('active_fade');
+    }, 500);
   });
 
 });

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -28,4 +28,15 @@ $(function(){
     }
   });
 
+  $('#sort_score').on('click', function(){
+    const reviewList = $('.review_list li');
+    reviewList.sort(function(a,b){
+      const aScore = Number($(a).find('.exp_score').text());
+      const bScore = Number($(b).find('.exp_score').text());
+      return bScore - aScore;
+    });
+    $('.review_list').empty();
+    $('.review_list').append(reviewList);
+  });
+
 });

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -32,7 +32,7 @@
               = @experience.score
             %span.review_count
               （
-            = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", '#', class: 'review_count review_link', data:{name: 'review_count'}
+            = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", experience_reviews_path(@experience.id), class: 'review_count review_link', data:{name: 'review_count'}
             %span.review_count
               ）
           %li.black
@@ -90,6 +90,7 @@
             -# 表示しているアクティビティに投稿されている口コミの件数を表示させる。
             %span{class: 'number', data:{name: 'review_count'}}
               = "(#{@experience.reviews.length}件)"
+            = link_to '', experience_reviews_path(@experience.id), class: 'reviews_index'
           %li.tab_2line
             %span
               写真

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -90,7 +90,7 @@
             -# 表示しているアクティビティに投稿されている口コミの件数を表示させる。
             %span{class: 'number', data:{name: 'review_count'}}
               = "(#{@experience.reviews.length}件)"
-            = link_to '', experience_reviews_path(@experience.id), class: 'reviews_index'
+            = link_to '', experience_reviews_path(@experience.id), class: 'exp_link'
           %li.tab_2line
             %span
               写真

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -1,0 +1,4 @@
+.header
+  = render 'shared/leh_header'
+.footer
+  = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -126,41 +126,43 @@
               投稿日
             %li.sort_link
               評価
-        .review_index_main_wrapper
-          .review_index_main_area
-            %h2.review_index_title
-              混雑がひどい
-            .review_index_score
-              .star_rating
-                %div{id: "star_rating1", class: 'star_rating_front'}
-                  ★★★★★
-                .star_rating_back
-                  ★★★★★
-              %span{class: 'rating_point exp_score'}
-                3.0
-            .triangle
-              ▲
-            .review_index_comment_area
-              %span.review_index_comment
-                行ったのは平日です。
-                %br/
-                いっときはコロナ対策のため、すいていて回りやすかったですが、いまやそれも過去の話…、9時のお仕事が始まった頃には、ピザ屋、すし屋、パン屋、ソーセージ屋、メガネ屋、はんこ屋など、受付終了が続出でした。
-                %br/
-                第一希望のお仕事はできたものの、第二、第三希望はかなわず。
-                %br/
-                お昼前には半数弱はお仕事受付終了、残り一時間の14時前の時点で、8割方のお仕事が受付終了になっていました。残っているお仕事に、子供と保護者が争うように殺到し、あっという間に長蛇の列ができては、次々と終了になっていっていました。
-                %br/
-                平日でこの状況って…。
-                %br/
-                なかなか、思うようにはお仕事ができず、待ち時間がけっこうありました。
-                %br/
-                あと、狭い通路で大声で喋ったり大笑いしている保護者がたくさんいて、うるさいのが気になりました。
-                %br/
-                詳細情報を見る
-            .review_index_user_area
-              .review_index_user_image
-              .review_index_user_name
-                ぺこりんさん
+        - @reviews.each_with_index do |review, index|
+          .review_index_main_wrapper
+            .review_index_main_area
+              %h2.review_index_title
+                = "#{review.title}"
+              .review_index_score
+                .star_rating
+                  %div{id: "star_rating#{index + 1}", class: 'star_rating_front'}
+                    ★★★★★
+                  .star_rating_back
+                    ★★★★★
+                %span{class: 'rating_point exp_score'}
+                  = "#{review.score.to_f}"
+              .triangle
+                ▲
+              .review_index_comment_area
+                %span.review_index_comment
+                  行ったのは平日です。
+                  %br/
+                  いっときはコロナ対策のため、すいていて回りやすかったですが、いまやそれも過去の話…、9時のお仕事が始まった頃には、ピザ屋、すし屋、パン屋、ソーセージ屋、メガネ屋、はんこ屋など、受付終了が続出でした。
+                  %br/
+                  第一希望のお仕事はできたものの、第二、第三希望はかなわず。
+                  %br/
+                  お昼前には半数弱はお仕事受付終了、残り一時間の14時前の時点で、8割方のお仕事が受付終了になっていました。残っているお仕事に、子供と保護者が争うように殺到し、あっという間に長蛇の列ができては、次々と終了になっていっていました。
+                  %br/
+                  平日でこの状況って…。
+                  %br/
+                  なかなか、思うようにはお仕事ができず、待ち時間がけっこうありました。
+                  %br/
+                  あと、狭い通路で大声で喋ったり大笑いしている保護者がたくさんいて、うるさいのが気になりました。
+                  %br/
+                  詳細情報を見る
+              .review_index_user_area
+                .review_index_user_image
+                  = review.user.image
+                .review_index_user_name
+                  = "#{review.user.name}さん"
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -126,9 +126,9 @@
             %ul.review_sort
               %li
                 並び替え
-              %li{id: 'sort_created_at', class: 'sort_link active_sort'}
+              %li{id: 'review_sort_2', class: 'sort_link active_sort'}
                 投稿日順
-              %li{id: 'sort_score', class: 'sort_link'}
+              %li{id: 'review_sort_1', class: 'sort_link'}
                 評価順
           %ul.review_list
             -# 口コミの数だけ口コミ表示処理を繰り返す。
@@ -143,7 +143,7 @@
                         ★★★★★
                       .star_rating_back
                         ★★★★★
-                    %span{class: 'rating_point exp_score'}
+                    %span{class: 'rating_point exp_score review_sort_material1'}
                       = review.score.to_f
                   .triangle
                     ▲
@@ -154,7 +154,7 @@
                     = user_image_attached?(review.user)
                     .review_index_user_name
                       = "#{review.user.name}さん"
-                  %span{class: 'review_created_at', style: 'display: none;'}
+                  %span{class: 'review_sort_material2', style: 'display: none;'}
                     = review.created_at
         -# 口コミが投稿されていない場合の表示
       - else

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -128,7 +128,7 @@
                 並び替え
               %li{class: 'sort_link active_sort'}
                 投稿日
-              %li.sort_link
+              %li{id: 'sort_score', class: 'sort_link'}
                 評価
           %ul.review_list
             -# 口コミの数だけ口コミ表示処理を繰り返す。

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -138,6 +138,28 @@
                   ★★★★★
               %span{class: 'rating_point exp_score'}
                 3.0
+            .triangle
+              ▲
+            .review_index_comment_area
+              %span.review_index_comment
+                行ったのは平日です。
+                %br/
+                いっときはコロナ対策のため、すいていて回りやすかったですが、いまやそれも過去の話…、9時のお仕事が始まった頃には、ピザ屋、すし屋、パン屋、ソーセージ屋、メガネ屋、はんこ屋など、受付終了が続出でした。
+                %br/
+                第一希望のお仕事はできたものの、第二、第三希望はかなわず。
+                %br/
+                お昼前には半数弱はお仕事受付終了、残り一時間の14時前の時点で、8割方のお仕事が受付終了になっていました。残っているお仕事に、子供と保護者が争うように殺到し、あっという間に長蛇の列ができては、次々と終了になっていっていました。
+                %br/
+                平日でこの状況って…。
+                %br/
+                なかなか、思うようにはお仕事ができず、待ち時間がけっこうありました。
+                %br/
+                あと、狭い通路で大声で喋ったり大笑いしている保護者がたくさんいて、うるさいのが気になりました。
+                %br/
+                詳細情報を見る
+            .review_index_user_area
+              .review_index_user_image
+              .review_index_user_name
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -160,6 +160,7 @@
             .review_index_user_area
               .review_index_user_image
               .review_index_user_name
+                ぺこりんさん
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -108,46 +108,58 @@
           %li.tab
             %span
               周辺情報
-      .review_index_content
-        .review_index_title_area
-          .review_index_title_icon
-          %h1.review_index_title
-            = "#{@experience.name}の口コミ一覧"
-        .review_index_info
-          .review_number
-            %span.review_number_part
-              = "1 - #{@reviews.length}件"
-            %span.review_number_all
-              = "（全#{@reviews.length.to_s(:delimited)}件中）"
-          %ul.review_sort
-            %li
-              並び替え
-            %li{class: 'sort_link active_sort'}
-              投稿日
-            %li.sort_link
-              評価
-        - @reviews.each_with_index do |review, index|
-          .review_index_main_wrapper
-            .review_index_main_area
-              %h2.review_index_title
-                = review.title
-              .review_index_score
-                .star_rating
-                  %div{id: "star_rating#{index + 1}", class: 'star_rating_front'}
-                    ★★★★★
-                  .star_rating_back
-                    ★★★★★
-                %span{class: 'rating_point exp_score'}
-                  = review.score.to_f
-              .triangle
-                ▲
-              .review_index_comment_area
-                %span.review_index_comment
-                  = review.comment
-              .review_index_user_area
-                = user_image_attached?(review.user)
-                .review_index_user_name
-                  = "#{review.user.name}さん"
+      -# 口コミが投稿されている場合の表示
+      - if @reviews.exists?
+        .review_index_content
+          .review_index_title_area
+            .review_index_title_icon
+            %h1.review_index_title
+              = "#{@experience.name}の口コミ一覧"
+          .review_index_info
+            -# 口コミ全数に対して、何件表示しているかを表示する。
+            .review_number
+              %span.review_number_part
+                = "1 - #{@reviews.length}件"
+              %span.review_number_all
+                = "（全#{@reviews.length.to_s(:delimited)}件中）"
+            -# 口コミの並び替えを行える。
+            %ul.review_sort
+              %li
+                並び替え
+              %li{class: 'sort_link active_sort'}
+                投稿日
+              %li.sort_link
+                評価
+          -# 口コミの数だけ口コミ表示処理を繰り返す。
+          - @reviews.each_with_index do |review, index|
+            .review_index_main_wrapper
+              .review_index_main_area
+                %h2.review_index_title
+                  = review.title
+                .review_index_score
+                  .star_rating
+                    %div{id: "star_rating#{index + 1}", class: 'star_rating_front'}
+                      ★★★★★
+                    .star_rating_back
+                      ★★★★★
+                  %span{class: 'rating_point exp_score'}
+                    = review.score.to_f
+                .triangle
+                  ▲
+                .review_index_comment_area
+                  %span.review_index_comment
+                    = review.comment
+                .review_index_user_area
+                  = user_image_attached?(review.user)
+                  .review_index_user_name
+                    = "#{review.user.name}さん"
+        -# 口コミが投稿されていない場合の表示
+      - else
+        .not_review_index_content
+          .review_index_title_area
+            .review_index_title_icon
+            %h1.review_index_title
+              = "#{@experience.name}の口コミはまだありません"
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -87,6 +87,7 @@
           %li.tab
             %span
               概要
+            = link_to '', experience_path(@experience.id), class: 'exp_link'
           %li{class: 'tab_2line active_tab'}
             %span
               口コミ
@@ -94,7 +95,6 @@
             -# 表示しているアクティビティに投稿されている口コミの件数を表示させる。
             %span{class: 'number', data:{name: 'review_count'}}
               = "(#{@experience.reviews.length.to_s(:delimited)}件)"
-            = link_to '', experience_reviews_path(@experience.id), class: 'reviews_index'
           %li.tab_2line
             %span
               写真
@@ -112,7 +112,7 @@
         .review_index_title_area
           .review_index_title_icon
           %h1.review_index_title
-            キッザニア甲子園の口コミ一覧
+            = "#{@experience.name}の口コミ一覧"
         .review_index_info
           .review_number
             %span.review_number_part
@@ -126,6 +126,10 @@
               投稿日
             %li.sort_link
               評価
+        .review_index_main_wrapper
+          .review_index_main_area
+            %h2.review_index_title
+              混雑がひどい
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -130,7 +130,7 @@
           .review_index_main_wrapper
             .review_index_main_area
               %h2.review_index_title
-                = "#{review.title}"
+                = review.title
               .review_index_score
                 .star_rating
                   %div{id: "star_rating#{index + 1}", class: 'star_rating_front'}
@@ -138,29 +138,14 @@
                   .star_rating_back
                     ★★★★★
                 %span{class: 'rating_point exp_score'}
-                  = "#{review.score.to_f}"
+                  = review.score.to_f
               .triangle
                 ▲
               .review_index_comment_area
                 %span.review_index_comment
-                  行ったのは平日です。
-                  %br/
-                  いっときはコロナ対策のため、すいていて回りやすかったですが、いまやそれも過去の話…、9時のお仕事が始まった頃には、ピザ屋、すし屋、パン屋、ソーセージ屋、メガネ屋、はんこ屋など、受付終了が続出でした。
-                  %br/
-                  第一希望のお仕事はできたものの、第二、第三希望はかなわず。
-                  %br/
-                  お昼前には半数弱はお仕事受付終了、残り一時間の14時前の時点で、8割方のお仕事が受付終了になっていました。残っているお仕事に、子供と保護者が争うように殺到し、あっという間に長蛇の列ができては、次々と終了になっていっていました。
-                  %br/
-                  平日でこの状況って…。
-                  %br/
-                  なかなか、思うようにはお仕事ができず、待ち時間がけっこうありました。
-                  %br/
-                  あと、狭い通路で大声で喋ったり大笑いしている保護者がたくさんいて、うるさいのが気になりました。
-                  %br/
-                  詳細情報を見る
+                  = review.comment
               .review_index_user_area
-                .review_index_user_image
-                  = review.user.image
+                = user_image_attached?(review.user)
                 .review_index_user_name
                   = "#{review.user.name}さん"
   .show_content_right

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -130,6 +130,14 @@
           .review_index_main_area
             %h2.review_index_title
               混雑がひどい
+            .review_index_score
+              .star_rating
+                %div{id: "star_rating1", class: 'star_rating_front'}
+                  ★★★★★
+                .star_rating_back
+                  ★★★★★
+              %span{class: 'rating_point exp_score'}
+                3.0
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -126,10 +126,10 @@
             %ul.review_sort
               %li
                 並び替え
-              %li{class: 'sort_link active_sort'}
-                投稿日
+              %li{id: 'sort_created_at', class: 'sort_link active_sort'}
+                投稿日順
               %li{id: 'sort_score', class: 'sort_link'}
-                評価
+                評価順
           %ul.review_list
             -# 口コミの数だけ口コミ表示処理を繰り返す。
             - @reviews.each_with_index do |review, index|
@@ -154,6 +154,8 @@
                     = user_image_attached?(review.user)
                     .review_index_user_name
                       = "#{review.user.name}さん"
+                  %span{class: 'review_created_at', style: 'display: none;'}
+                    = review.created_at
         -# 口コミが投稿されていない場合の表示
       - else
         .not_review_index_content

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -1,4 +1,19 @@
 .header
   = render 'shared/leh_header'
+.menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
+  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+  %span
+    &nbsp;>&nbsp;
+  = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
+  %span
+    &nbsp;>&nbsp;
+  %strong
+    = link_to "#{@experience.name}", experience_path(@experience.id), id: 'change_link', style: 'color: blue'
+  %span
+    &nbsp;>&nbsp;
+  %strong
+    = "#{@experience.name}の口コミ一覧"
+  %span{id: 'category_id', style: 'display:none'}
+    = @experience.genre.category.id
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -15,5 +15,100 @@
     = "#{@experience.name}の口コミ一覧"
   %span{id: 'category_id', style: 'display:none'}
     = @experience.genre.category.id
+.show_content_wrapper
+  .show_content_left
+    .show_left_info
+      .show_info_left
+        %ul
+          -# カテゴリーのアイコン画像とアクティビティの名称を表示させる。
+          %li.show_info_name
+            %div{id: 'category_icon'}
+            %h1.experience_name
+              = @experience.name
+          -# アクティビティの評価点とそれに対応した5段階評価を表示させる。
+          %li.show_info_score
+            .star_rating
+              %div{id: "star_rating0", class: 'star_rating_front'}
+                ★★★★★
+              .star_rating_back
+                ★★★★★
+            %span{class: 'rating_point exp_score'}
+              = @experience.score
+            %span.review_count
+              （
+            = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", experience_reviews_path(@experience.id), class: 'review_count review_link', data:{name: 'review_count'}
+            %span.review_count
+              ）
+          %li.black
+          -# アクティビティのエリア・ジャンルを表示させる。
+          %li.area_wrapper
+            %span.area
+              エリア
+            = link_to "#{@experience.area.island.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.area.name}",'#', id: 'change_link', class: 'link_to'
+          %li.genre_wrapper
+            %span.genre
+              ジャンル
+            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.genre.name}",'#', id: 'change_link', class: 'link_to'
+      .show_info_right
+        -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
+        - if user_signed_in?
+          %ul
+            %li.post_reviews
+              = icon('far', 'comment-dots', class: 'fa-flip-horizontal')
+              口コミ投稿
+              = link_to '', new_experience_review_path(@experience.id), class: 'btn'
+            %li.share_act
+              = icon('fas', 'share')
+              シェアする
+              = link_to '','#', class: 'btn'
+          %ul.show_info_right_down
+            %li.favorite
+              -# お気に入りされていればお気に入り登録の解除ができて、まだならお気に入り登録ができる。
+              - if @experience.already_favorited?(current_user, @experience)
+                = icon("fas", "star")
+                = link_to '', experience_favorites_path(@experience.id), method: :delete, class: 'btn favorite_btn'
+              - else
+                = icon("far", "star")
+                = link_to '', experience_favorites_path(@experience.id), method: :post, class: 'btn favorite_btn'
+              = @experience.favorites.length.to_s(:delimited)
+            %li.have_been_place
+              - if @experience.already_histories?(current_user, @experience)
+                = icon('fas', 'check')
+                = link_to '', experience_histories_path(@experience.id), method: :delete, class: 'btn have_been_btn'
+              - else
+                = icon('fas', 'shoe-prints',class: 'fa-rotate-270')
+                = link_to '', experience_histories_path(@experience.id), method: :post, class: 'btn have_been_btn'
+              行った
+    .show_left_main
+      .show_left_main_tab
+        %ul.experience_tabs
+          %li{class: 'tab active_tab'}
+            %span
+              概要
+          %li.tab_2line
+            %span
+              口コミ
+            %br/
+            -# 表示しているアクティビティに投稿されている口コミの件数を表示させる。
+            %span{class: 'number', data:{name: 'review_count'}}
+              = "(#{@experience.reviews.length}件)"
+            = link_to '', experience_reviews_path(@experience.id), class: 'reviews_index'
+          %li.tab_2line
+            %span
+              写真
+            %br/
+            -# 表示しているアクティビティに投稿されている写真の件数を表示させる。
+            %span.number
+              = "(#{@images_count}枚)"
+          %li.tab
+            %span
+              地図
+          %li.tab
+            %span
+              周辺情報
+      .show_left_main_content
+  .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -84,16 +84,16 @@
     .show_left_main
       .show_left_main_tab
         %ul.experience_tabs
-          %li{class: 'tab active_tab'}
+          %li.tab
             %span
               概要
-          %li.tab_2line
+          %li{class: 'tab_2line active_tab'}
             %span
               口コミ
             %br/
             -# 表示しているアクティビティに投稿されている口コミの件数を表示させる。
             %span{class: 'number', data:{name: 'review_count'}}
-              = "(#{@experience.reviews.length}件)"
+              = "(#{@experience.reviews.length.to_s(:delimited)}件)"
             = link_to '', experience_reviews_path(@experience.id), class: 'reviews_index'
           %li.tab_2line
             %span
@@ -108,7 +108,24 @@
           %li.tab
             %span
               周辺情報
-      .show_left_main_content
+      .review_index_content
+        .review_index_title_area
+          .review_index_title_icon
+          %h1.review_index_title
+            キッザニア甲子園の口コミ一覧
+        .review_index_info
+          .review_number
+            %span.review_number_part
+              = "1 - #{@reviews.length}件"
+            %span.review_number_all
+              = "（全#{@reviews.length.to_s(:delimited)}件中）"
+          %ul.review_sort
+            %li
+              並び替え
+            %li{class: 'sort_link active_sort'}
+              投稿日
+            %li.sort_link
+              評価
   .show_content_right
 .footer
   = render 'shared/leh_footer'

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -130,29 +130,30 @@
                 投稿日
               %li.sort_link
                 評価
-          -# 口コミの数だけ口コミ表示処理を繰り返す。
-          - @reviews.each_with_index do |review, index|
-            .review_index_main_wrapper
-              .review_index_main_area
-                %h2.review_index_title
-                  = review.title
-                .review_index_score
-                  .star_rating
-                    %div{id: "star_rating#{index + 1}", class: 'star_rating_front'}
-                      ★★★★★
-                    .star_rating_back
-                      ★★★★★
-                  %span{class: 'rating_point exp_score'}
-                    = review.score.to_f
-                .triangle
-                  ▲
-                .review_index_comment_area
-                  %span.review_index_comment
-                    = review.comment
-                .review_index_user_area
-                  = user_image_attached?(review.user)
-                  .review_index_user_name
-                    = "#{review.user.name}さん"
+          %ul.review_list
+            -# 口コミの数だけ口コミ表示処理を繰り返す。
+            - @reviews.each_with_index do |review, index|
+              %li.review_index_main_wrapper
+                .review_index_main_area
+                  %h2.review_index_title
+                    = review.title
+                  .review_index_score
+                    .star_rating
+                      %div{id: "star_rating#{index + 1}", class: 'star_rating_front'}
+                        ★★★★★
+                      .star_rating_back
+                        ★★★★★
+                    %span{class: 'rating_point exp_score'}
+                      = review.score.to_f
+                  .triangle
+                    ▲
+                  .review_index_comment_area
+                    %span.review_index_comment
+                      = review.comment
+                  .review_index_user_area
+                    = user_image_attached?(review.user)
+                    .review_index_user_name
+                      = "#{review.user.name}さん"
         -# 口コミが投稿されていない場合の表示
       - else
         .not_review_index_content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   }
   resources :users, only: [:show]
   resources :experiences, only: [:show], shallow: true do
-    resources :reviews, only: %i[new create]
+    resources :reviews, only: %i[index new create]
     resource :histories, only: %i[create destroy]
     resource :favorites, only: %i[create destroy]
   end


### PR DESCRIPTION
## 概要
* アクティビティに投稿された口コミの一覧表示ページと口コミの表示順変更機能を実装する。

## 変更点
* `reviewsコントローラー`に`indexアクション`を定義し、アクティビティに投稿された口コミの情報をインスタンスで受け渡し。
* `口コミ一覧が表示された後に`評価順・投稿日順`のボタンを選択すると、選択したボタンの表示順になる様に`review.js`内に関数を定義。

## テスト結果とテスト項目
- [x] 口コミ一覧が表示された後に、並び替えボタンを選択するとそのボタンの表示順に口コミの一覧表示が変更される。
- [x] 選択されている並び替えボタンは再度選択できない様になっている。

## Issue番号
close #59 