### PR TITLE
検索結果一覧ページの並び順変更機能実装

### DIFF
--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -395,15 +395,10 @@
       }
 
       .sort_link {
-        color: $linkColor;
-        text-decoration: underline;
-        cursor: pointer;
+        @include sortLink();
 
         &.active_sort {
-          color: #000000;
-          font-weight: bold;
-          text-decoration: none;
-          cursor: auto;
+          @include activeSort();
         }
       }
     }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -4,10 +4,12 @@
   color: #ff4500;
   border-bottom: 3px solid #ff4500;
 }
+
 @mixin subTitle {
   font-weight: bold;
   font-size: 18px;
 }
+
 @mixin requiredItem {
   margin: 0 0 4px 5px;
   font-size: 11px;
@@ -15,12 +17,14 @@
   color: #ffffff;
   background-color: #ff4500;
 }
+
 @mixin titleIcon {
   height: 22px;
   width: 5px;
   border-radius: 2px;
   background-color: #ff4500;
 }
+
 @mixin contentNumberInfo {
   display: flex;
   justify-content: space-between;
@@ -29,54 +33,73 @@
   border-bottom: 3px solid #eee;
   padding-bottom: 6px;
 }
+
 @keyframes fadeIn {
-  0% {opacity: 0;}
-  100% {opacity: 1;}
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
 }
-.review_new_wrapper{
+
+.review_new_wrapper {
   width: 950px;
   margin: 0 auto 100px;
   display: flex;
   justify-content: space-between;
-  .review_new_form{
+
+  .review_new_form {
     width: 750px;
     color: $colorBlack;
-    &_name{
+
+    &_name {
       margin-top: 28px;
-      &_title{
+
+      &_title {
         display: flex;
-        .head_icon{
+
+        .head_icon {
           @include titleIcon();
         }
-        .head_name{
+
+        .head_name {
           font-size: 18px;
           font-weight: bold;
           margin-left: 8px;
         }
       }
-      &_info{
+
+      &_info {
         display: flex;
         margin-top: 27px;
-        .info_image{
+
+        .info_image {
           height: 107px;
           width: 160px;
           background-color: black;
         }
-        .info_name{
+
+        .info_name {
           margin-left: 15px;
-          .exp_icon_name{
+
+          .exp_icon_name {
             display: flex;
-            .exp_name{
+
+            .exp_name {
               font-weight: bold;
               margin: 5px 0 0 8px;
             }
           }
-          .exp_area{
+
+          .exp_area {
             margin-top: 9px;
             font-size: 11px;
             word-spacing: 0;
           }
-          .exp_address{
+
+          .exp_address {
             margin-top: 5px;
             font-size: 12px;
             word-spacing: 0;
@@ -84,102 +107,129 @@
         }
       }
     }
-    &_score{
+
+    &_score {
       margin-top: 25px;
-      .review_score_title{
+
+      .review_score_title {
         @include reviewTitle();
-        .score_title{
+
+        .score_title {
           @include subTitle();
         }
-        .score_info{
+
+        .score_info {
           font-size: 12px;
           margin-bottom: 3px;
         }
-        .required_item{
+
+        .required_item {
           @include requiredItem();
         }
       }
-      .review_score{
+
+      .review_score {
         display: flex;
         font-size: 30px;
         margin: 5px 0 0 1px;
-        .review_score_star{
+
+        .review_score_star {
           width: 42px;
           color: #ffa500;
           cursor: pointer;
         }
-        .review_btn{
+
+        .review_btn {
           display: none;
         }
       }
     }
-    &_content{
-      .review_content_title{
+
+    &_content {
+      .review_content_title {
         @include reviewTitle();
         margin-top: 40px;
-        .score_title{
+
+        .score_title {
           @include subTitle();
         }
-        .required_item{
+
+        .required_item {
           @include requiredItem();
         }
       }
-      .review_content_main{
+
+      .review_content_main {
         margin-top: 17px;
-        .review_title_info{
+
+        .review_title_info {
           display: flex;
-          .title_icon{
+
+          .title_icon {
             @include titleIcon();
             height: 15px;
             border-radius: 1px;
           }
-          .title_name{
+
+          .title_name {
             font-size: 14px;
             font-weight: bold;
             padding-left: 6px;
             line-height: 16px;
           }
         }
-        .review_main_info{
+
+        .review_main_info {
           @extend .review_title_info;
           margin-top: 12px;
-          .main_icon{
+
+          .main_icon {
             @extend .title_icon;
           }
-          .main_name{
-            @extend .title_name;  
+
+          .main_name {
+            @extend .title_name;
           }
         }
-        .review_title_main{
+
+        .review_title_main {
           padding-top: 6px;
-          .review_title{
+
+          .review_title {
             height: 24px;
             width: 752px;
             font-size: 13px;
           }
         }
-        .review_main{
+
+        .review_main {
           @extend .review_title_main;
           padding-top: 8px;
-          .review{
+
+          .review {
             @extend .review_title;
             resize: none;
             height: 182px;
-            input:focus::placeholder{
+
+            input:focus::placeholder {
               color: transparent;
             }
           }
         }
       }
-      .review_picture{
+
+      .review_picture {
         margin-top: 30px;
-        .review_picture_title{
+
+        .review_picture_title {
           @include reviewTitle();
-          .picture_title{
+
+          .picture_title {
             @include subTitle();
           }
         }
-        .picture_btn{
+
+        .picture_btn {
           @include backgroundGradient();
           position: relative;
           display: flex;
@@ -192,7 +242,8 @@
           border-radius: 3px;
           color: #787878;
           font-size: 19px;
-          .picture_add{
+
+          .picture_add {
             position: absolute;
             top: 0;
             left: 0;
@@ -205,23 +256,27 @@
             color: $colorBlack;
             cursor: pointer;
           }
-          .rev_picture{
+
+          .rev_picture {
             height: 100%;
             width: 100%;
           }
         }
-        .picture_info{
+
+        .picture_info {
           font-size: 12px;
           text-align: right;
           margin-block-start: 1px;
           margin-block-end: 0;
         }
-        .picture_main_wrapper{
+
+        .picture_main_wrapper {
           margin-top: 10px;
           border-radius: 4px;
           background-color: #eee;
           display: flex;
-          .picture_show_area{
+
+          .picture_show_area {
             display: flex;
             flex-wrap: wrap;
             height: 215px;
@@ -229,22 +284,27 @@
             margin: 20px auto;
             border: 3px dotted $gray;
             background-color: #ffffff;
-            .preview_wrap{
+
+            .preview_wrap {
               margin: 20px 0 10px 20px;
-              .preview{
+
+              .preview {
                 height: 156px;
                 width: 209px;
               }
-              .picture_delete{
+
+              .picture_delete {
                 margin-top: 5px;
                 font-size: 12px;
                 width: 67px;
                 cursor: pointer;
-                i{
+
+                i {
                   color: #9a9a9a;
                   font-size: 11px;
                 }
-                .delete_btn{
+
+                .delete_btn {
                   margin-left: 3px;
                   color: #0000ff;
                   text-decoration: underline;
@@ -254,13 +314,15 @@
           }
         }
       }
-      .review_submit{
+
+      .review_submit {
         margin-top: 31px;
         height: 100px;
         border-top: 1px solid $gray;
         display: flex;
         justify-content: center;
-        .submit{
+
+        .submit {
           display: flex;
           align-items: center;
           justify-content: center;
@@ -278,53 +340,66 @@
       }
     }
   }
-  .review_old_show{
+
+  .review_old_show {
     height: 1000px;
     width: 180px;
   }
 }
-.review_index_content{
+
+.review_index_content {
   @extend .show_left_main_content;
   min-height: 302px;
   height: auto !important;
   height: 302px;
-  .review_index_title_area{
+
+  .review_index_title_area {
     display: flex;
-    .review_index_title_icon{
+
+    .review_index_title_icon {
       @include titleIcon();
       margin: 1px 5px 0 0;
     }
-    .review_index_title{
+
+    .review_index_title {
       @extend .experience_name;
     }
   }
-  .review_index_info{
+
+  .review_index_info {
     @include contentNumberInfo();
-    .review_number{
+
+    .review_number {
       display: flex;
-      .review_number_part{
+
+      .review_number_part {
         font-size: 16px;
       }
-      .review_number_all{
+
+      .review_number_all {
         font-size: 12px;
         margin: 4px 0 0 5px;
       }
     }
-    .review_sort{
+
+    .review_sort {
       display: flex;
       font-size: 12px;
       margin: 2px 64px 0 0;
-      li{
+
+      li {
         height: 12px;
         line-height: 12px;
         border-right: 1px solid $gray;
         padding: 0 5px;
       }
-      .sort_link{
-        color: #0000ff;
+
+      .sort_link {
+        color: $linkColor;
         text-decoration: underline;
         cursor: pointer;
-        &.active_sort{
+
+        &.active_sort {
           color: #000000;
           font-weight: bold;
           text-decoration: none;
@@ -333,54 +408,66 @@
       }
     }
   }
-  .review_list{
-    &.active_fade{
+
+  .review_list {
+    &.active_fade {
       animation: fadeIn 0.5s;
     }
-    .review_index_main_wrapper{
+
+    .review_index_main_wrapper {
       border-bottom: 3px solid #eee;
       padding: 12px 0 15px;
       color: $colorBlack;
-      .review_index_main_area{
+
+      .review_index_main_area {
         width: 99%;
         margin: 0 auto;
-        .review_index_title{
+
+        .review_index_title {
           font-size: 14px;
           font-weight: bold;
           color: #0000ff;
           text-decoration: underline;
         }
-        .review_index_score{
+
+        .review_index_score {
           margin-top: 2px;
           @include expScore;
-          .rating_point{
+
+          .rating_point {
             font-size: 16px;
           }
         }
-        .triangle{
+
+        .triangle {
           color: #eee;
           margin: -5px 0 0 27px;
           font-size: 14px;
         }
-        .review_index_comment_area{
+
+        .review_index_comment_area {
           margin-top: -7px;
           padding: 8px;
           border-radius: 6px;
           background-color: #eee;
-          .review_index_comment{
+
+          .review_index_comment {
             font-size: 20px;
           }
         }
-        .review_index_user_area{
+
+        .review_index_user_area {
           display: flex;
           margin-top: 10px;
-          .user_image{
+
+          .user_image {
             height: 30px;
             width: 30px;
             margin-right: 9px;
             background-color: $gray;
           }
-          .review_index_user_name{
+
+          .review_index_user_name {
             font-size: 11px;
             line-height: 32px;
           }
@@ -389,50 +476,62 @@
     }
   }
 }
-.not_review_index_content{
+
+.not_review_index_content {
   @extend .review_index_content;
   height: calc(100vh - 489px);
 }
-.experience_photo_content{
+
+.experience_photo_content {
   @extend .show_left_main_content;
   min-height: 302px;
   height: auto !important;
   height: 302px;
-  .experience_photo_title_area{
+
+  .experience_photo_title_area {
     display: flex;
-    .experience_photo_title_icon{
+
+    .experience_photo_title_icon {
       @include titleIcon();
       margin: 1px 5px 0 0;
       // @extend .review_index_title_icon;
     }
-    .experience_photo_title{
+
+    .experience_photo_title {
       @extend .experience_name;
     }
   }
-  .experience_photo_info{
+
+  .experience_photo_info {
     @include contentNumberInfo();
     margin-top: 5px;
     border-bottom: none;
-    .experience_photo_number{
+
+    .experience_photo_number {
       display: flex;
-      &_part{
+
+      &_part {
         font-size: 16px;
       }
-      &_all{
+
+      &_all {
         font-size: 12px;
         margin-top: 4px;
       }
     }
   }
-  .experience_photo_list{
+
+  .experience_photo_list {
     display: flex;
     flex-wrap: wrap;
     padding: 3px;
-    .experience_photo_area{
+
+    .experience_photo_area {
       margin: 0 22px 26px 0;
       border: 1px solid $gray;
     }
-    .experience_photo_area_right{
+
+    .experience_photo_area_right {
       @extend .experience_photo_area;
       margin-right: 0;
     }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -405,10 +405,6 @@
   }
 
   .review_list {
-    &.active_fade {
-      animation: fadeIn 0.5s;
-    }
-
     .review_index_main_wrapper {
       border-bottom: 3px solid #eee;
       padding: 12px 0 15px;

--- a/app/assets/stylesheets/pages/_search.scss
+++ b/app/assets/stylesheets/pages/_search.scss
@@ -87,23 +87,14 @@ $gray: #ccc;
           display: flex;
           align-items: center;
 
-          .order_list {
+          .sort_link {
+            @include sortLink();
             margin-left: 5px;
             padding-right: 6px;
-            color: $linkColor;
-            cursor: pointer;
-            text-decoration: underline;
             border-right: 1px solid $gray;
 
-            &.active_order {
-              color: #333333;
-              font-weight: bold;
-              text-decoration: none;
-              cursor: auto;
-            }
-
-            &.order_none {
-              border: none;
+            &.active_sort {
+              @include activeSort();
             }
           }
         }

--- a/app/assets/stylesheets/pages/_search.scss
+++ b/app/assets/stylesheets/pages/_search.scss
@@ -144,6 +144,7 @@ $gray: #ccc;
             margin-left: 11px;
             height: 100%;
             width: 100%;
+            position: relative;
 
             &_main {
               line-height: 18px;
@@ -173,9 +174,22 @@ $gray: #ccc;
               line-height: 12px;
             }
 
-            &_price {
-              color: #ff0000;
-              font-weight: bold;
+
+            &_favorite {
+              position: absolute;
+              right: 0;
+              bottom: 0;
+              color: #333333;
+              font-size: 22px;
+
+              .star_icon {
+                color: #ffa500;
+              }
+
+              .experience_favorites_number {
+                font-weight: bold;
+                line-height: 26px;
+              }
             }
           }
         }

--- a/app/assets/stylesheets/pages/_search.scss
+++ b/app/assets/stylesheets/pages/_search.scss
@@ -1,23 +1,28 @@
 $upHeight: 29px;
-$linkColor: blue;
+$linkColor: #0000ff;
 $gray: #ccc;
-.content_header{
+
+.content_header {
   margin: 0 245px;
   font-size: 10px;
 }
-.content_main{
+
+.content_main {
   height: 100%;
   width: calc(100% - 490px);
   margin: 0 245px;
   display: flex;
-  &_left{
+
+  &_left {
     width: 740px;
-    &_header{
+
+    &_header {
       @extend .content_main_left;
       display: flex;
       padding-top: 5px;
       margin-bottom: 23px;
-      .content_title{
+
+      .content_title {
         font-size: 24px;
         font-weight: bold;
         color: #333333;
@@ -25,32 +30,39 @@ $gray: #ccc;
         padding-left: 3px;
       }
     }
-    &_info{
+
+    &_info {
       @extend .content_main_left;
       height: 50px;
       color: #333333;
       margin-bottom: 10px;
-      &_up{
+
+      &_up {
         height: $upHeight;
         display: flex;
         justify-content: space-between;
-        .ul_number{
+
+        .ul_number {
           display: flex;
           align-items: flex-end;
-          .number{
+
+          .number {
             word-spacing: 0px;
           }
-          .all_number{
+
+          .all_number {
             @extend .number;
             font-size: 12px;
             margin-bottom: 2px;
           }
         }
-        .ul_list{
+
+        .ul_list {
           @extend .ul_number;
           width: 100px;
           justify-content: flex-end;
-          .list{
+
+          .list {
             width: 24px;
             margin: 0 0 5px 8px;
             text-align: center;
@@ -58,99 +70,119 @@ $gray: #ccc;
             background-color: #969696;
             color: white;
             cursor: pointer;
-            &.list_active{
+
+            &.list_active {
               background-color: #333333;
             }
           }
         }
       }
-      &_down{
+
+      &_down {
         height: 14px;
         font-size: 12px;
         padding-top: 5px;
-        .order{
+
+        .order {
           display: flex;
           align-items: center;
-          .order_list{
+
+          .order_list {
             margin-left: 5px;
             padding-right: 6px;
             color: $linkColor;
             cursor: pointer;
             text-decoration: underline;
             border-right: 1px solid $gray;
-            &.text_active{
+
+            &.active_order {
               color: #333333;
               font-weight: bold;
               text-decoration: none;
               cursor: auto;
             }
-            &.order_none{
+
+            &.order_none {
               border: none;
             }
           }
         }
       }
     }
-    &_main{
+
+    &_main {
       cursor: pointer;
-      &_list{
+
+      &_list {
         // height: 320px;
         margin-bottom: 15px;
         border-radius: 10px;
         border: 1px solid $gray;
-        .content_main_header{
+
+        .content_main_header {
           height: 87px;
           padding: 10px 0;
           margin: 0 10px;
           border-bottom: 2px dotted $gray;
-          &_name{
-            .show_experiences{
+
+          &_name {
+            .show_experiences {
               font-size: 18px;
               color: $linkColor;
               font-weight: bold;
             }
           }
-          .experience_score{
+
+          .experience_score {
             @include expScore;
           }
-          &_place{
+
+          &_place {
             margin-top: -4px;
             font-size: 12px;
             word-spacing: 0;
           }
         }
-        .content_main_outline{
+
+        .content_main_outline {
           height: 161px;
           margin: 20px 11px 10px;
           display: flex;
-          .content_outline{
+
+          .content_outline {
             margin-left: 11px;
             height: 100%;
             width: 100%;
-            &_main{
+
+            &_main {
               line-height: 18px;
               color: $linkColor;
               font-weight: bold;
               font-size: 14px;
               margin-bottom: 5px;
             }
-            &_sub{
+
+            &_sub {
               font-size: 11px;
               line-height: 15px;
               margin-bottom: 8px;
             }
-            &_category{
+
+            &_category {
               font-size: 11px;
               margin-bottom: 10px;
-              .category_icon{
+
+              .category_icon {
                 color: #ffa500;
               }
             }
-            &_age{
+
+            &_age {
               font-size: 12px;
               line-height: 12px;
             }
-            &_price{
+
+            &_price {
               color: #ff0000;
               font-weight: bold;
             }
@@ -159,15 +191,18 @@ $gray: #ccc;
       }
     }
   }
-  &_right{
+
+  &_right {
     width: calc(100% - 740px);
-    .right_content_area{
+
+    .right_content_area {
       width: 180px;
       margin: 74px 0 0 auto;
       border: 1px solid $gray;
       border-radius: 4px;
       padding-top: 4px;
-      &_title{
+
+      &_title {
         color: #333333;
         font-size: 12px;
         font-weight: bold;
@@ -175,28 +210,33 @@ $gray: #ccc;
         margin: 4px 0 9px 5px;
         padding: 0 3px;
       }
-      .right_content{
+
+      .right_content {
         height: 38px;
         margin: 3px 0 7px;
         padding: 0 5px;
         display: flex;
-        .fav_image{
+
+        .fav_image {
           margin-right: 4px;
         }
-        .fav_name{
+
+        .fav_name {
           font-size: 12px;
           font-weight: bold;
           color: $linkColor;
           margin-top: 10px;
         }
       }
-      .content_sub{
+
+      .content_sub {
         @extend .right_content;
         height: 47px;
         margin-top: 7px;
         border-top: 1px dotted $gray;
         padding-top: 9px;
-        .name_sub{
+
+        .name_sub {
           font-size: 12px;
           font-weight: bold;
           color: $linkColor;

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -1,101 +1,139 @@
 $transition: .2s ease-in-out;
+
 @mixin expScore {
   display: flex;
-  .star_rating{
+
+  .star_rating {
     margin-right: 6px;
     width: 5em;
     line-height: 22px;
     font-size: 22px;
     position: relative;
-    &_front{
+
+    &_front {
       position: absolute;
       top: 0;
       left: 0;
       overflow: hidden;
       color: #ffa500;
     }
-    &_back{
+
+    &_back {
       color: $gray;
     }
   }
-  .rating_point{
+
+  .rating_point {
     color: black;
     font-weight: bold;
     line-height: 26px;
   }
-  .review_count{
+
+  .review_count {
     @extend .rating_point;
     font-weight: unset;
     font-size: 12px;
     line-height: 25px;
   }
-  .review_link{
+
+  .review_link {
     color: $linkColor;
   }
 }
+
 @mixin backgroundGradient {
   background: linear-gradient(#ffffff, #e4e4e4);
 }
-*, :after, :before{
+
+@mixin sortLink {
+  color: $linkColor;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+@mixin activeSort {
+  color: #000000;
+  font-weight: bold;
+  text-decoration: none;
+  cursor: auto;
+}
+
+*,
+:after,
+:before {
   box-sizing: border-box;
   margin: 0;
 }
-html{
+
+html {
   font-size: 16px;
   word-spacing: 1px;
 }
-body{
+
+body {
   color: rgb(102, 102, 102);
 }
-div{
+
+div {
   display: block;
 }
-input:focus::placeholder{
+
+input:focus::placeholder {
   color: transparent;
 }
-textarea:focus::placeholder{
+
+textarea:focus::placeholder {
   color: transparent;
 }
-p{
+
+p {
   display: block;
   margin-block-start: 1em;
   margin-block-end: 1em;
   margin-inline-start: 0px;
   margin-inline-end: 0px;
 }
-ul{
+
+ul {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
-li{
+
+li {
   display: list-item;
 }
+
 img {
   vertical-align: bottom;
 }
-.btn{
+
+.btn {
   position: absolute;
   top: 0;
   left: 0;
   height: 100%;
   width: 100%;
 }
-.hidden{
+
+.hidden {
   display: none;
 }
-.leh_header{
-  .header_wrapper{
+
+.leh_header {
+  .header_wrapper {
     padding: 10px 190px 0 50px;
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-    .leh_icon{
+
+    .leh_icon {
       height: 80px;
       width: 80px;
       margin-bottom: 5px;
       position: relative;
-      .root_link{
+
+      .root_link {
         position: absolute;
         top: 0;
         left: 0;
@@ -103,23 +141,28 @@ img {
         width: 100%;
       }
     }
-    .leh_sign_login{
+
+    .leh_sign_login {
       width: 420px;
       margin: 0;
       float: right;
       text-align: right;
-      .sign_login_wrapper{
+
+      .sign_login_wrapper {
         display: flex;
         flex-direction: column;
         justify-content: center;
         height: 45px;
-        .sign_login{
+
+        .sign_login {
           display: flex;
           align-items: center;
           justify-content: flex-end;
-          li{
+
+          li {
             margin-left: 10px;
-            .sl_name{
+
+            .sl_name {
               color: #008dde;
               font-size: 14px;
             }
@@ -129,7 +172,8 @@ img {
     }
   }
 }
-.button_cv{
+
+.button_cv {
   height: 50px;
   border: none;
   outline: 0;
@@ -140,60 +184,73 @@ img {
   background-color: #00b900;
   font-weight: 700;
 }
-.leh_footer{
+
+.leh_footer {
   background-color: whitesmoke;
   height: 90px;
   width: 100%;
   display: flex;
   justify-content: center;
-  .leh_footer_main{
+
+  .leh_footer_main {
     height: 100%;
     width: calc(#{$searchLeftWidth} + 25px + #{$searchRightWidth});
     display: flex;
     justify-content: space-between;
     align-items: center;
-    .leh_footer_link{
+
+    .leh_footer_link {
       display: flex;
       justify-content: space-around;
       align-items: center;
-      .leh_privacy{
+
+      .leh_privacy {
         margin-right: 10px;
-        .leh_privacy_link{
+
+        .leh_privacy_link {
           font-size: 12px;
           text-decoration: none;
           color: gray;
         }
       }
-      .leh_email{
+
+      .leh_email {
         font-size: 12px;
         text-decoration: none;
         color: gray;
       }
     }
-    .leh_copyright{
+
+    .leh_copyright {
       font-size: 10px;
       color: #808080;
     }
   }
 }
-#link_main{
+
+#link_main {
   padding: 10px 0 5px 0;
   border-bottom: 1px dotted #ccc;
-  a{
+
+  a {
     text-decoration-line: underline;
     outline: none;
   }
-  a:visited{
+
+  a:visited {
     color: #069;
   }
 }
-.link_to{
+
+.link_to {
   color: blue;
 }
-.link_hover{
-  text-decoration-line: underline!important;
-  color: #ffa500!important;
+
+.link_hover {
+  text-decoration-line: underline !important;
+  color: #ffa500 !important;
 }
-.btn_hover{
-  background-color: #ffa500!important;
+
+.btn_hover {
+  background-color: #ffa500 !important;
 }

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -254,3 +254,7 @@ img {
 .btn_hover {
   background-color: #ffa500 !important;
 }
+
+.active_fade {
+  animation: fadeIn 0.5s;
+}

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -16,7 +16,7 @@ class ExperiencesController < ApplicationController
     @category = Category.find_by(search: params[:name])
     @experiences = []
     Genre.where(category_id: @category.id).find_each do |genre|
-      Experience.includes(:genre).includes(:area).where(genre_id: genre.id).find_each { |exp| @experiences << exp }
+      Experience.includes(:favorites).includes(:genre).includes(:area).where(genre_id: genre.id).find_each { |exp| @experiences << exp }
     end
     render 'experiences/category'
   end

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -1,61 +1,67 @@
-'use strict';
+"use strict";
 
-$(function(){
-
-  let clickedId = 0
-  // 口コミページ表示直後は投稿日順で表示されている為、2を変数に代入している。
-  let activeSortId = 2
+$(function () {
+  let clickedId = 0;
+  // 表示ページに'並び替えボタン'があれば、初期選択されているボタンの'id'を'activeSortId'
+  let activeSortId = null;
+  if ($(".active_sort").length) {
+    activeSortId = $(".active_sort")[0].id.match(/\d/)[0];
+  }
 
   // '★'をクリックした位置から左側の'★'がホバーを外しても表示が変更されたままで、クリックした位置から右側が非選択状態になる。
-  $('[id^="review_score_"]').on('click', function(){
+  $('[id^="review_score_"]').on("click", function () {
     clickedId = Number($(this)[0].value);
-    for (let index = (clickedId + 1); index <= 5; index++){
-      $(`#star_btn${index}`)[0].innerText = '☆';
-    };
+    for (let index = clickedId + 1; index <= 5; index++) {
+      $(`#star_btn${index}`)[0].innerText = "☆";
+    }
   });
   $('[id^="star_btn"]').on({
     // '★'をホバーするとホバーした位置から左側にある'★'を全て表示変更させる。
-    'mouseover': function(){
+    mouseover: function () {
       const starId = $(this)[0].id.slice(-1);
-      for (let index = starId; index > 0; index--){
-        $(`#star_btn${index}`)[0].innerText = '★';
-      };
+      for (let index = starId; index > 0; index--) {
+        $(`#star_btn${index}`)[0].innerText = "★";
+      }
     },
     // '★'のホバーを外すと、クリックされていない部分を'☆'状態に戻す。
-    'mouseout': function(){
+    mouseout: function () {
       const starId = $(this)[0].id.slice(-1);
-      for (let index = starId; index > clickedId; index--){
-        $(`#star_btn${index}`)[0].innerText = '☆';
-      };
-    }
+      for (let index = starId; index > clickedId; index--) {
+        $(`#star_btn${index}`)[0].innerText = "☆";
+      }
+    },
   });
 
-  // 並び替えの'評価順・投稿日順'ボタンをクリックすると、アクティビティの評価点・投稿日の降順に表示を変更する。
-  $('[id*="_sort_"]').on('click', function(){
-    const sortName = this.id.match(/(.*)(?=_sort_)/)[0]
+  // 並び替え用ボタンをクリックすると、ボタンに表示されている項目の降順に表示を変更する。
+  $('[id*="_sort_"]').on("click", function () {
+    const sortName = this.id.match(/(.*)(?=_sort_)/)[0];
     const sortId = Number(this.id.match(/\d/)[0]);
     // すでに選択されている並び順では、動作しない様に否定文で分岐させる。
     if (!(sortId === activeSortId)) {
-      // 表示している口コミの要素一覧を変数に格納する。
+      // 表示している要素一覧を変数に格納する。
       const sortList = $(`.${sortName}_list li`);
-      sortList.sort(function(a,b){
+      sortList.sort(function (a, b) {
         const aText = $(a).find(`.${sortName}_sort_material${sortId}`).text();
         const bText = $(b).find(`.${sortName}_sort_material${sortId}`).text();
         if (aText > bText) {
-          return -1
+          return -1;
         } else {
-          return 1
+          return 1;
         }
       });
-      $(`#${sortName}_sort_${activeSortId}`).removeClass('active_sort').addClass('change_link');
+      $(`#${sortName}_sort_${activeSortId}`)
+        .removeClass("active_sort")
+        .addClass("change_link");
       // 選択した並び順のID数値を再代入している。
       activeSortId = sortId;
-      $(this).addClass('active_sort').removeClass('change_link').removeClass('link_hover');
-      $(`.${sortName}_list`).empty().append(sortList).addClass('active_fade');
-      setTimeout(function(){
-        $(`.${sortName}_list`).removeClass('active_fade');
+      $(this)
+        .addClass("active_sort")
+        .removeClass("change_link")
+        .removeClass("link_hover");
+      $(`.${sortName}_list`).empty().append(sortList).addClass("active_fade");
+      setTimeout(function () {
+        $(`.${sortName}_list`).removeClass("active_fade");
       }, 500);
     }
   });
-
 });

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -46,10 +46,10 @@ $(function(){
           return 1
         }
       });
-      $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort');
+      $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort').addClass('change_link');
       // 選択した並び順のID数値を再代入している。
       activeReviewSortId = reviewSortId;
-      $(this).addClass('active_sort');
+      $(this).addClass('active_sort').removeClass('change_link');
       $('.review_list').empty();
       $('.review_list').append(reviewList);
       $('.review_list').addClass('active_fade');

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -37,25 +37,23 @@ $(function(){
     // すでに選択されている並び順では、動作しない様に否定文で分岐させる。
     if (!(sortId === activeSortId)) {
       // 表示している口コミの要素一覧を変数に格納する。
-      const reviewList = $('.review_list li');
-      reviewList.sort(function(a,b){
-        const aText = $(a).find(`.review_sort_material${sortId}`).text();
-        const bText = $(b).find(`.review_sort_material${sortId}`).text();
+      const sortList = $(`.${sortName}_list li`);
+      sortList.sort(function(a,b){
+        const aText = $(a).find(`.${sortName}_sort_material${sortId}`).text();
+        const bText = $(b).find(`.${sortName}_sort_material${sortId}`).text();
         if (aText > bText) {
           return -1
         } else {
           return 1
         }
       });
-      $(`#review_sort_${activeSortId}`).removeClass('active_sort').addClass('change_link');
+      $(`#${sortName}_sort_${activeSortId}`).removeClass('active_sort').addClass('change_link');
       // 選択した並び順のID数値を再代入している。
       activeSortId = sortId;
       $(this).addClass('active_sort').removeClass('change_link').removeClass('link_hover');
-      $('.review_list').empty();
-      $('.review_list').append(reviewList);
-      $('.review_list').addClass('active_fade');
+      $(`.${sortName}_list`).empty().append(sortList).addClass('active_fade');
       setTimeout(function(){
-        $('.review_list').removeClass('active_fade');
+        $(`.${sortName}_list`).removeClass('active_fade');
       }, 500);
     }
   });

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -4,7 +4,7 @@ $(function(){
 
   let clickedId = 0
   // 口コミページ表示直後は投稿日順で表示されている為、2を変数に代入している。
-  let activeReviewSortId = 2
+  let activeSortId = 2
 
   // '★'をクリックした位置から左側の'★'がホバーを外しても表示が変更されたままで、クリックした位置から右側が非選択状態になる。
   $('[id^="review_score_"]').on('click', function(){
@@ -31,24 +31,25 @@ $(function(){
   });
 
   // 並び替えの'評価順・投稿日順'ボタンをクリックすると、アクティビティの評価点・投稿日の降順に表示を変更する。
-  $('[id^="review_sort_"]').on('click', function(){
-    const reviewSortId = Number(this.id.match(/\d/)[0]);
+  $('[id*="_sort_"]').on('click', function(){
+    const sortName = this.id.match(/(.*)(?=_sort_)/)[0]
+    const sortId = Number(this.id.match(/\d/)[0]);
     // すでに選択されている並び順では、動作しない様に否定文で分岐させる。
-    if (!(reviewSortId === activeReviewSortId)) {
+    if (!(sortId === activeSortId)) {
       // 表示している口コミの要素一覧を変数に格納する。
       const reviewList = $('.review_list li');
       reviewList.sort(function(a,b){
-        const aText = $(a).find(`.review_sort_material${reviewSortId}`).text();
-        const bText = $(b).find(`.review_sort_material${reviewSortId}`).text();
+        const aText = $(a).find(`.review_sort_material${sortId}`).text();
+        const bText = $(b).find(`.review_sort_material${sortId}`).text();
         if (aText > bText) {
           return -1
         } else {
           return 1
         }
       });
-      $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort').addClass('change_link');
+      $(`#review_sort_${activeSortId}`).removeClass('active_sort').addClass('change_link');
       // 選択した並び順のID数値を再代入している。
-      activeReviewSortId = reviewSortId;
+      activeSortId = sortId;
       $(this).addClass('active_sort').removeClass('change_link').removeClass('link_hover');
       $('.review_list').empty();
       $('.review_list').append(reviewList);

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -49,7 +49,7 @@ $(function(){
       $(`#review_sort_${activeReviewSortId}`).removeClass('active_sort').addClass('change_link');
       // 選択した並び順のID数値を再代入している。
       activeReviewSortId = reviewSortId;
-      $(this).addClass('active_sort').removeClass('change_link');
+      $(this).addClass('active_sort').removeClass('change_link').removeClass('link_hover');
       $('.review_list').empty();
       $('.review_list').append(reviewList);
       $('.review_list').addClass('active_fade');

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -39,10 +39,11 @@ $(window).on('load',function(){
 
 $(function(){
   // 'id名'に'change'と入っている要素をホバーするとリンクの表示を変更させる。
-  $('[id^="change"]').on('mouseover',function(){
+  $('[class*="change_link"]').on('mouseover',function(){
+    console.log('test');
     $(this).addClass('link_hover');
   });
-  $('[id^="change"]').on('mouseout',function(){
+  $('[class*="change_link"]').on('mouseout',function(){
     $(this).removeClass('link_hover');
   });
   // 'ボタン'にホバーすると表示色を変更させる。
@@ -52,4 +53,6 @@ $(function(){
   $('[id^="btn"]').on('mouseout',function(){
     $(this).removeClass('btn_hover');
   });
+
+  $
 });

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -1,57 +1,59 @@
-'use strict';
+"use strict";
 
-$(window).on('load',function(){
+$(window).on("load", function () {
   const categoryIcons = [
-    'hotel_icon',
-    'lunch_icon',
-    'car_icon',
-    'leisure_icon',
-    'landmark_icon',
-    'shopping_icon'
+    "hotel_icon",
+    "lunch_icon",
+    "car_icon",
+    "leisure_icon",
+    "landmark_icon",
+    "shopping_icon",
   ];
   const url = location.pathname;
-  const conditions = (url == '/shopping') || (url == '/landmark') || (url == '/leisure') || (url == '/rentacar') || (url == '/dinner') || (url == '/hotel') || (/\/experiences\/[0-9]{1,}/.test(url));
-  if(conditions) {
+  const conditions =
+    url == "/shopping" ||
+    url == "/landmark" ||
+    url == "/leisure" ||
+    url == "/rentacar" ||
+    url == "/dinner" ||
+    url == "/hotel" ||
+    /\/experiences\/[0-9]{1,}/.test(url);
+  if (conditions) {
     // 'category_id'を取得して、その'id'に対応したアイコン画像用のクラスを配列から取得して追加させる。
-    const categoryIcon = $('#category_icon');
-    const categoryId = $('#category_id')[0].innerText;
+    const categoryIcon = $("#category_icon");
+    const categoryId = $("#category_id")[0].innerText;
     categoryIcon.addClass(`${categoryIcons[categoryId - 1]}`);
   }
-  if(conditions) {
+  if (conditions) {
     // exp_scoreクラスを複数取得して、ノードリストから配列へ変換し、各要素毎に処理をしていく。
-    const expScoreArray = Array.from($('.exp_score'));
+    const expScoreArray = Array.from($(".exp_score"));
     expScoreArray.forEach((element, index) => {
       const expScore = element.innerText;
       // 'expScore'に'20'を乗算することにより'%'の数値にして、`star_rating`の'width'プロパティの値に設定する。
       const starRatingPercent = expScore * 20;
-      $(`#star_rating${index}`).css('width', `${starRatingPercent}%`);
+      $(`#star_rating${index}`).css("width", `${starRatingPercent}%`);
     });
   }
   // 詳細ページの5段階評価ごとの'%'を取得して数値に対応したグラフを表示させる。
-  if((/\/experiences\/[0-9]{1,}/.test(url)) && !(/\/experiences\/[0-9]{1,}\//.test(url))) {
+  if (
+    /\/experiences\/[0-9]{1,}/.test(url) &&
+    !/\/experiences\/[0-9]{1,}\//.test(url)
+  ) {
     const showScoreArray = Array.from($('[id*="score_"]'));
     showScoreArray.reverse().forEach((element, index) => {
       const percent = element.innerText.match(/\d+/)[0];
-      $(`#graph_score${index + 1}`).css('width', `${percent}%`);
+      $(`#graph_score${index + 1}`).css("width", `${percent}%`);
     });
   }
 });
 
-$(function(){
-  // 'id名'に'change'と入っている要素をホバーするとリンクの表示を変更させる。
-  $(document).on('mouseover','[class*="change_link"]',function(){
-    $(this).addClass('link_hover');
-  }),
-  $(document).on('mouseout','[class*="change_link"]',function(){
-    $(this).removeClass('link_hover');
+$(function () {
+  // 'id名'に'change'と入っている要素をホバーしている時だけリンクの表示を変更させる。
+  $(document).on("mouseover mouseout", '[class*="change_link"]', function () {
+    $(this).toggleClass("link_hover");
   });
   // 'ボタン'にホバーすると表示色を変更させる。
-  $('[id^="btn"]').on('mouseover',function(){
-    $(this).addClass('btn_hover');
+  $('[id^="btn"]').on("mouseover mouseout", function () {
+    $(this).toggleClass("btn_hover");
   });
-  $('[id^="btn"]').on('mouseout',function(){
-    $(this).removeClass('btn_hover');
-  });
-
-  $()
 });

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -38,8 +38,16 @@ $(window).on('load',function(){
 });
 
 $(function(){
+  // ページ内に'sort_link'クラスがあり、その要素が'active_sort'クラスを持っていなければ、
+  if($('.sort_link').length){
+    $('.sort_link').each(function(){
+      if (!($(this).hasClass('active_sort'))){
+        $(this).addClass('change_link');
+      }
+    });
+  };
   // 'id名'に'change'と入っている要素をホバーするとリンクの表示を変更させる。
-  $('[class*="change_link"]').on('mouseover',function(){
+  $(document).on('mouseover','[class*="change_link"]',function(){
     console.log('test');
     $(this).addClass('link_hover');
   });
@@ -54,5 +62,5 @@ $(function(){
     $(this).removeClass('btn_hover');
   });
 
-  $
+  $()
 });

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -38,20 +38,11 @@ $(window).on('load',function(){
 });
 
 $(function(){
-  // ページ内に'sort_link'クラスがあり、その要素が'active_sort'クラスを持っていなければ、
-  if($('.sort_link').length){
-    $('.sort_link').each(function(){
-      if (!($(this).hasClass('active_sort'))){
-        $(this).addClass('change_link');
-      }
-    });
-  };
   // 'id名'に'change'と入っている要素をホバーするとリンクの表示を変更させる。
   $(document).on('mouseover','[class*="change_link"]',function(){
-    console.log('test');
     $(this).addClass('link_hover');
-  });
-  $('[class*="change_link"]').on('mouseout',function(){
+  }),
+  $(document).on('mouseout','[class*="change_link"]',function(){
     $(this).removeClass('link_hover');
   });
   // 'ボタン'にホバーすると表示色を変更させる。

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -32,10 +32,8 @@
           %li
             並び順：
           %li{id: 'experience_sort_1', class: 'sort_link change_link'}
-            安い順
-          %li{id: 'experience_sort_2', class: 'sort_link change_link'}
             口コミランク順
-          %li{id: 'experience_sort_3', class: 'sort_link active_sort'}
+          %li{id: 'experience_sort_2', class: 'sort_link active_sort'}
             おすすめ順
     %ul{class: 'content_main_left_main experience_list'}
       - @experiences.each_with_index do |exp,index|
@@ -49,7 +47,7 @@
                   ★★★★★
                 .star_rating_back
                   ★★★★★
-              %span{class: 'rating_point exp_score'}
+              %span{class: 'rating_point exp_score experience_sort_material1'}
                 = exp.score
               %span.review_count
                 （
@@ -70,10 +68,10 @@
               .content_outline_category
                 = icon('fas', 'flag', class: 'category_icon')
                 = exp.genre.name
-              .content_outline_age
-                対象年齢
-              .content_outline_price
-                平均費用〜
+              %div{class: 'content_outline_favorite experience_sort_material2'}
+                = icon('fas', 'star', class: 'star_icon')
+                %span.experience_favorites_number
+                  = exp.favorites.length
   .content_main_right
     - if user_signed_in? && current_user.favorites.exists?
       .right_content_area

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -31,11 +31,11 @@
         %ul.order
           %li
             並び順：
-          %li{id: '', class: 'order_list change_link'}
+          %li{id: '', class: 'sort_link'}
             安い順
-          %li{id: '', class: 'order_list change_link'}
+          %li{id: '', class: 'sort_link'}
             口コミランク順
-          %li{class: 'order_list active_order change_link'}
+          %li{class: 'sort_link active_sort'}
             おすすめ順
     %ul.content_main_left_main
       - @experiences.each_with_index do |exp,index|

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -37,7 +37,7 @@
             口コミランク順
           %li{id: 'experience_sort_3', class: 'sort_link active_sort'}
             おすすめ順
-    %ul.content_main_left_main
+    %ul{class: 'content_main_left_main experience_list'}
       - @experiences.each_with_index do |exp,index|
         %li.content_main_left_main_list
           .content_main_header

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -31,11 +31,11 @@
         %ul.order
           %li
             並び順：
-          %li{id: '', class: 'sort_link change_link'}
+          %li{id: 'experience_sort_1', class: 'sort_link change_link'}
             安い順
-          %li{id: '', class: 'sort_link change_link'}
+          %li{id: 'experience_sort_2', class: 'sort_link change_link'}
             口コミランク順
-          %li{class: 'sort_link active_sort'}
+          %li{id: 'experience_sort_3', class: 'sort_link active_sort'}
             おすすめ順
     %ul.content_main_left_main
       - @experiences.each_with_index do |exp,index|

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -2,7 +2,7 @@
   = render 'shared/leh_header'
 .content_header
   .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-    = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+    = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
     %span
       &nbsp;>&nbsp;
     %strong
@@ -31,18 +31,18 @@
         %ul.order
           %li
             並び順：
-          %li{id: 'change_link', class: 'order_list'}
+          %li{id: '', class: 'order_list change_link'}
             安い順
-          %li{id: 'change_link', class: 'order_list'}
+          %li{id: '', class: 'order_list change_link'}
             口コミランク順
-          %li{class: 'order_list text_active order_none'}
+          %li{class: 'order_list active_order change_link'}
             おすすめ順
     %ul.content_main_left_main
       - @experiences.each_with_index do |exp,index|
         %li.content_main_left_main_list
           .content_main_header
             .content_main_header_name
-              = link_to "#{exp.name}", "experiences/#{exp.id}", id: 'change_link', class: 'show_experiences'
+              = link_to "#{exp.name}", "experiences/#{exp.id}", class: 'show_experiences change_link'
             .experience_score
               .star_rating
                 %div{id: "star_rating#{index}", class: 'star_rating_front'}
@@ -81,7 +81,7 @@
           最近のお気に入りスポット
         .right_content
           = image_tag '', height: '38px', width: '51px', class: 'fav_image'
-          %p{id: 'change_link', class: 'fav_name'}
+          %p{class: 'fav_name change_link'}
             テスト
         .content_sub
           = image_tag '', height: '38px', width: '51px', class: 'fav_image'

--- a/app/views/experiences/category.html.haml
+++ b/app/views/experiences/category.html.haml
@@ -31,9 +31,9 @@
         %ul.order
           %li
             並び順：
-          %li{id: '', class: 'sort_link'}
+          %li{id: '', class: 'sort_link change_link'}
             安い順
-          %li{id: '', class: 'sort_link'}
+          %li{id: '', class: 'sort_link change_link'}
             口コミランク順
           %li{class: 'sort_link active_sort'}
             おすすめ順

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -1,10 +1,10 @@
 .header
   = render 'shared/leh_header'
 .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+  = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
-  = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
+  = link_to "#{@experience.genre.category.name}", '/shopping', class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
   %strong
@@ -40,13 +40,13 @@
           %li.area_wrapper
             %span.area
               エリア
-            = link_to "#{@experience.area.island.name}",'#', id: 'change_link', class: 'link_to'
-            = link_to "#{@experience.area.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.area.island.name}",'#', class: 'link_to change_link'
+            = link_to "#{@experience.area.name}",'#', class: 'link_to change_link'
           %li.genre_wrapper
             %span.genre
               ジャンル
-            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", id: 'change_link', class: 'link_to'
-            = link_to "#{@experience.genre.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", class: 'link_to change_link'
+            = link_to "#{@experience.genre.name}",'#', class: 'link_to change_link'
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
         - if user_signed_in?

--- a/app/views/reviews/experience_photos.html.haml
+++ b/app/views/reviews/experience_photos.html.haml
@@ -1,10 +1,10 @@
 .header
   = render 'shared/leh_header'
 .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+  = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
-  = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
+  = link_to "#{@experience.genre.category.name}", '/shopping', class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
   %strong
@@ -40,13 +40,13 @@
           %li.area_wrapper
             %span.area
               エリア
-            = link_to "#{@experience.area.island.name}",'#', id: 'change_link', class: 'link_to'
-            = link_to "#{@experience.area.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.area.island.name}",'#', class: 'link_to change_link'
+            = link_to "#{@experience.area.name}",'#', class: 'link_to change_link'
           %li.genre_wrapper
             %span.genre
               ジャンル
-            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", id: 'change_link', class: 'link_to'
-            = link_to "#{@experience.genre.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", class: 'link_to change_link'
+            = link_to "#{@experience.genre.name}",'#', class: 'link_to change_link'
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
         - if user_signed_in?

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -129,7 +129,7 @@
                 並び替え
               %li{id: 'review_sort_2', class: 'sort_link active_sort'}
                 投稿日順
-              %li{id: 'review_sort_1', class: 'change_link sort_link'}
+              %li{id: 'review_sort_1', class: 'sort_link change_link'}
                 評価順
           %ul.review_list
             -# 口コミの数だけ口コミ表示処理を繰り返す。

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -1,14 +1,14 @@
 .header
   = render 'shared/leh_header'
 .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-  = link_to 'トップページ', root_path, id: 'change_link', style: 'color: blue'
+  = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
-  = link_to "#{@experience.genre.category.name}", '/shopping', id: 'change_link', style: 'color: blue'
+  = link_to "#{@experience.genre.category.name}", '/shopping', class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
   %strong
-    = link_to "#{@experience.name}", experience_path(@experience.id), id: 'change_link', style: 'color: blue'
+    = link_to "#{@experience.name}", experience_path(@experience.id), class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
   %strong
@@ -44,13 +44,13 @@
           %li.area_wrapper
             %span.area
               エリア
-            = link_to "#{@experience.area.island.name}",'#', id: 'change_link', class: 'link_to'
-            = link_to "#{@experience.area.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.area.island.name}",'#', class: 'link_to change_link'
+            = link_to "#{@experience.area.name}",'#', class: 'link_to change_link'
           %li.genre_wrapper
             %span.genre
               ジャンル
-            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", id: 'change_link', class: 'link_to'
-            = link_to "#{@experience.genre.name}",'#', id: 'change_link', class: 'link_to'
+            = link_to "#{@experience.genre.category.name}","/#{@experience.genre.category.search}", class: 'link_to change_link'
+            = link_to "#{@experience.genre.name}",'#', class: 'link_to change_link'
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
         - if user_signed_in?
@@ -129,7 +129,7 @@
                 並び替え
               %li{id: 'review_sort_2', class: 'sort_link active_sort'}
                 投稿日順
-              %li{id: 'review_sort_1', class: 'sort_link'}
+              %li{id: 'review_sort_1', class: 'change_link sort_link'}
                 評価順
           %ul.review_list
             -# 口コミの数だけ口コミ表示処理を繰り返す。


### PR DESCRIPTION
## 概要
* アクティビティ検索結果ページの並び順変更ボタンの機能を実装する。

## 変更点
* `change_link`をidからclass名に変更。
* 各アクティビティに対するお気に入り数を検索一覧ページに表示。

## テスト結果とテスト項目
- [x] 並び替え用のボタンを選択すると、ボタンの内容に添った表示順に変更する。

## Issue番号
close #49 