### PR TITLE
会員登録入力フォームのエラーメッセージ表示機能実装

### DIFF
--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -54,7 +54,6 @@ $regHeight: 881px;
                     appearance: none;
                     height: 50px;
                     width: $v100;
-                    transition: border .2s ease-out;
                     outline: 0;
                     border-radius: 6px;
                     padding: 15px;

--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -64,7 +64,8 @@ $regHeight: 881px;
                     font-size: 12px;
                     color: red;
                     position: absolute;
-                    top: 53px;
+                    left: 0;
+                    top: 54px;
                   }
                 }
                 .remember_me_password{

--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -62,7 +62,7 @@ $regHeight: 881px;
                   }
                   .signin_up_error_message{
                     font-size: 12px;
-                    color: red;
+                    color: #ff0000;
                     position: absolute;
                     left: 0;
                     top: 54px;

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -179,7 +179,6 @@ img {
   outline: 0;
   border-radius: 6px;
   cursor: pointer;
-  transition: $transition;
   color: #fff;
   background-color: #00b900;
   font-weight: 700;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,6 +12,7 @@ require("preview.js")
 require("top_page.js")
 require("search.js")
 require("review.js")
+require("sign_in_up.js")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -1,39 +1,48 @@
 'use strict';
 
 $(function(){
+  const errorInput = { 'background-color': '#ffff00', 'border': '1px solid #ff0000'}
   // 会員登録入力フォームのフォーカスが外れた時にバリデーションが正しいが判定する関数。
   $('.signin_up_input').on('blur', function(){
     $(this).next().remove();
+    $(this).css({ 'background-color': 'white', 'border': '1px solid #ccc' });
     // フォーカスが外れた時に、何も入力がなければ入力を促すメッセージを表示させる。
     if (!(this.value)) {
       $(this).parent().append('<span class="signin_up_error_message">この項目は必須です</span>');
+      $(this).css(errorInput);
     } else {
       // フォーカスが外れた際に、その入力フォームのid名の'user_'以降の文字列によって分岐させる。
       switch (this.id.match(/(?<=user_).*$/)[0]) {
         case 'email':
           if (!(this.value.match(/@/))) {
             $(this).parent().append('<span class="signin_up_error_message">メールアドレスに「@」が挿入されておりません</span>');
+            $(this).css(errorInput);
           }
           break;
         case 'password':
           // パスワードが8文字以下の場合。
           if (!(this.value.match(/.{8,}/))) {
             $(this).parent().append('<span class="signin_up_error_message">パスワードは8文字以上必要です</span>');
+            $(this).css(errorInput);
           } else {
             // 数字が入っていない場合。
             if (this.value.match(/^(?!.*[0-9]).*$/)) {
             $(this).parent().append('<span class="signin_up_error_message">数字が挿入されておりません</span>');
+            $(this).css(errorInput);
             // 英字が入っていない場合。
             } else if (this.value.match(/^(?!.*[a-zA-Z]).*$/)) {
             $(this).parent().append('<span class="signin_up_error_message">英字が挿入されておりません</span>');
+            $(this).css(errorInput);
             } else if (this.value.match(/^(?!.*[!-\/:-@\[-`\{-~].*[!-\/:-@\[-`\{-~]).*$/)) {
               $(this).parent().append('<span class="signin_up_error_message">記号は2回以上が必要です</span>');
+              $(this).css(errorInput);
             }
           }
           break;
         case 'password_confirmation':
           if (!(this.value === $('#user_password')[0].value)) {
             $(this).parent().append('<span class="signin_up_error_message">パスワードと同じ内容を入力してください</span>');
+            $(this).css(errorInput);
           }
           break;
       }

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -1,1 +1,13 @@
 'use strict';
+
+$(function(){
+  // 会員登録入力フォームのフォーカスが外れた時にバリデーションが正しいが判定する関数。
+  $('.signin_up_input').on('blur', function(){
+    // console.log(!(this.value));
+    if (!(this.value)) {
+      $(this).parent().append('<span class="signin_up_error_message">この項目は必須です</span>');
+    } else {
+      $(this).next().remove();
+    }
+  });
+});

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -16,7 +16,22 @@ $(function(){
           }
           break;
         case 'password':
-          console.log(this.value);
+          // パスワードが8文字以下の場合。
+          if (!(this.value.match(/.{8,}/))) {
+            $(this).parent().append('<span class="signin_up_error_message">パスワードは8文字以上必要です</span>');
+          } else {
+            // 数字が入っていない場合。
+            if (this.value.match(/^(?!.*[0-9]).*$/)) {
+            $(this).parent().append('<span class="signin_up_error_message">数字が挿入されておりません</span>');
+            // 英字が入っていない場合。
+            } else if (this.value.match(/^(?!.*[a-zA-Z]).*$/)) {
+            $(this).parent().append('<span class="signin_up_error_message">英字が挿入されておりません</span>');
+            } else if (this.value.match(/^(?!.*[!-\/:-@\[-`\{-~].*[!-\/:-@\[-`\{-~]).*$/)) {
+              $(this).parent().append('<span class="signin_up_error_message">記号は2回以上が必要です</span>');
+            }
+          }
+            // console.log('0-9')
+          // console.log(this.value);
           break;
         case 'password_confirmation':
           console.log('password_confirmation');

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -11,7 +11,9 @@ $(function(){
       // フォーカスが外れた際に、その入力フォームのid名の'user_'以降の文字列によって分岐させる。
       switch (this.id.match(/(?<=user_).*$/)[0]) {
         case 'email':
-          console.log('email');
+          if (!(this.value.match(/@/))) {
+            $(this).parent().append('<span class="signin_up_error_message">メールアドレスに「@」が挿入されておりません</span>');
+          }
           break;
         case 'password':
           console.log('password');

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -30,11 +30,11 @@ $(function(){
               $(this).parent().append('<span class="signin_up_error_message">記号は2回以上が必要です</span>');
             }
           }
-            // console.log('0-9')
-          // console.log(this.value);
           break;
         case 'password_confirmation':
-          console.log('password_confirmation');
+          if (!(this.value === $('#user_password')[0].value)) {
+            $(this).parent().append('<span class="signin_up_error_message">パスワードと同じ内容を入力してください</span>');
+          }
           break;
       }
     }

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -16,7 +16,7 @@ $(function(){
           }
           break;
         case 'password':
-          console.log('password');
+          console.log(this.value);
           break;
         case 'password_confirmation':
           console.log('password_confirmation');

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -3,10 +3,23 @@
 $(function(){
   // 会員登録入力フォームのフォーカスが外れた時にバリデーションが正しいが判定する関数。
   $('.signin_up_input').on('blur', function(){
+    $(this).next().remove();
+    // フォーカスが外れた時に、何も入力がなければ入力を促すメッセージを表示させる。
     if (!(this.value)) {
       $(this).parent().append('<span class="signin_up_error_message">この項目は必須です</span>');
     } else {
-      $(this).next().remove();
+      // フォーカスが外れた際に、その入力フォームのid名の'user_'以降の文字列によって分岐させる。
+      switch (this.id.match(/(?<=user_).*$/)[0]) {
+        case 'email':
+          console.log('email');
+          break;
+        case 'password':
+          console.log('password');
+          break;
+        case 'password_confirmation':
+          console.log('password_confirmation');
+          break;
+      }
     }
   });
 });

--- a/app/javascript/sign_in_up.js
+++ b/app/javascript/sign_in_up.js
@@ -3,7 +3,6 @@
 $(function(){
   // 会員登録入力フォームのフォーカスが外れた時にバリデーションが正しいが判定する関数。
   $('.signin_up_input').on('blur', function(){
-    // console.log(!(this.value));
     if (!(this.value)) {
       $(this).parent().append('<span class="signin_up_error_message">この項目は必須です</span>');
     } else {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,8 @@ class User < ApplicationRecord
   with_options presence: true do
     validates :name
     validates :email, format: { with: /@/ }
-
+    # 半角英数字8以上で、記号を2回以上使用すること
+    validates :password, format: { with: /\A(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!-\/:-@\[-`\{-~].*[!-\/:-@\[-`\{-~])([a-zA-Z0-9!-\/:-@\[-`\{-~]{8,})\z/ }
   end
 
   has_one_attached :image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,11 @@ class User < ApplicationRecord
          :validatable,
          :omniauthable,
          omniauth_providers: %i[facebook google_oauth2]
-  validates :name, presence: true
+  with_options presence: true do
+    validates :name
+    validates :email, format: { with: /@/ }
+
+  end
 
   has_one_attached :image
   has_many :reviews, dependent: :destroy

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -5,10 +5,11 @@
       .signin_up_main_wrapper
         .signin_up_main
           .signin_up_main_content
+            -# = render "devise/shared/error_messages", resource: @user
             %span.register_text 会員登録
             .signin_up_form
               / 入力フォーム
-              = form_with model: @user, url: user_registration_path, local: true, class: 'signin_up_user' do |f|
+              = form_with model: @user, url: user_registration_path, html: { novalidate: true, class: 'signin_up_user' }, local: true do |f|
                 .signin_up_form_input
                   = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name', class: 'signin_up_input'
                 .signin_up_form_input

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -12,20 +12,19 @@
                 = render "devise/shared/error_messages", resource: @user
                 .signin_up_form_input
                   = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name', class: 'signin_up_input'
-                  %span{style: 'display:none'}, class: 'signin_up_error_message'}この項目は必須です
                 .signin_up_form_input
                   = f.email_field :email, placeholder: 'メールアドレス', autocomplete: "email", autocorrect: 'off', autocapitalize: 'off', class: 'signin_up_input'
-                  %span{style: 'display:none'}, class: 'signin_up_error_message'}この項目は必須です
+                  %span{style: 'display:none', class: 'signin_up_error_message'}この項目は必須です
                 -# SNS認証での新規登録ならパスワード入力欄を消去し、登録ボタンを押した際にsns_auth: true というparamsを送信する。
                 - if @sns_id.present?
                   = hidden_field_tag :sns_auth, true
                 - else
                   .signin_up_form_input
                     = f.password_field :password, placeholder: 'パスワード（8～20文字・半角英数字・記号を2種以上）', maxlength: '20', autocomplete: "new-password", class: 'signin_up_input'
-                    %span{style: 'display:none'}, class: 'signin_up_error_message'}この項目は必須です
+                    %span{style: 'display:none', class: 'signin_up_error_message'}この項目は必須です
                   .signin_up_form_input
                     = f.password_field :password_confirmation, placeholder: '上記と同じパスワードを入力してください', autocomplete: "new-password", class: 'signin_up_input'
-                    %span{style: 'display:none'}, class: 'signin_up_error_message'}この項目は必須です
+                    %span{class: 'signin_up_error_message'}この項目は必須です
                 = f.submit "登録する", class: 'button_cv signin_up_button'
               / 入力フォーム
             .social_login
@@ -50,8 +49,8 @@
               .testuser_sign_in_form
                 %span.testuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
                 = form_with model: @user, url: user_session_path, local: true, class: 'testuser_login_form' do |f|
-                  = f.hidden_field :email, :value => 'test@test.com'
-                  = f.hidden_field :password, :value => 'testuser1'
+                  = f.hidden_field :email, :value => 'test@test.com', id: 'test_user_email'
+                  = f.hidden_field :password, :value => 'testuser1', id: 'test_user_password'
                   = f.submit "こちら", class: 'testuser_login_button'
               / テストユーザーとしてログインするためのフォーム
       / フッター

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -9,22 +9,18 @@
             .signin_up_form
               / 入力フォーム
               = form_with model: @user, url: user_registration_path, local: true, class: 'signin_up_user' do |f|
-                = render "devise/shared/error_messages", resource: @user
                 .signin_up_form_input
                   = f.text_field :name, placeholder: '氏名（例：畑中三郎）', autocomplete: 'name', class: 'signin_up_input'
                 .signin_up_form_input
                   = f.email_field :email, placeholder: 'メールアドレス', autocomplete: "email", autocorrect: 'off', autocapitalize: 'off', class: 'signin_up_input'
-                  %span{style: 'display:none', class: 'signin_up_error_message'}この項目は必須です
                 -# SNS認証での新規登録ならパスワード入力欄を消去し、登録ボタンを押した際にsns_auth: true というparamsを送信する。
                 - if @sns_id.present?
                   = hidden_field_tag :sns_auth, true
                 - else
                   .signin_up_form_input
                     = f.password_field :password, placeholder: 'パスワード（8～20文字・半角英数字・記号を2種以上）', maxlength: '20', autocomplete: "new-password", class: 'signin_up_input'
-                    %span{style: 'display:none', class: 'signin_up_error_message'}この項目は必須です
                   .signin_up_form_input
                     = f.password_field :password_confirmation, placeholder: '上記と同じパスワードを入力してください', autocomplete: "new-password", class: 'signin_up_input'
-                    %span{class: 'signin_up_error_message'}この項目は必須です
                 = f.submit "登録する", class: 'button_cv signin_up_button'
               / 入力フォーム
             .social_login

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -22,7 +22,7 @@
                     = f.password_field :password, placeholder: 'パスワード（8～20文字・半角英数字・記号を2種以上）', maxlength: '20', autocomplete: "new-password", class: 'signin_up_input'
                   .signin_up_form_input
                     = f.password_field :password_confirmation, placeholder: '上記と同じパスワードを入力してください', autocomplete: "new-password", class: 'signin_up_input'
-                = f.submit "登録する", class: 'button_cv signin_up_button'
+                = f.submit "登録する", id: 'btn', class: 'button_cv signin_up_button'
               / 入力フォーム
             .social_login
               %span{class: 'social_login_title'}こちらもご利用いただけます


### PR DESCRIPTION
## 概要
* 会員登録フォーム入力時に、内容不備があった場合にエラーメッセージで不備内容を表示する様実装する。

## 変更点
* `sign_in_up.js`を作成し、モデルのバリデーション内容に従い入力不備があったら入力フォームのフォーカスが外れた際に表示する様コードを記述。

## テスト結果とテスト項目
- [x] 入力フォームにバリデーションに引っかかる内容を入力してフォーカスを外した際に、エラーメッセージが表示される。

## Issue番号
close #32 