### PR TITLE
エリア・ジャンルでの検索機能実装

### DIFF
--- a/app/assets/stylesheets/pages/_experiences.scss
+++ b/app/assets/stylesheets/pages/_experiences.scss
@@ -48,7 +48,7 @@ $colorBlack: #333333;
           display: flex;
           font-size: 12px;
           margin-top: 12px;
-          .area{
+          .area_name{
             font-weight: bold;
             margin-right: 40px;
           }
@@ -59,7 +59,7 @@ $colorBlack: #333333;
         .genre_wrapper{
           @extend .area_wrapper;
           margin-top: 5px;
-          .genre{
+          .genre_name{
             font-weight: bold;
             margin-right: 29px;
           }

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -21,7 +21,6 @@ class ExperiencesController < ApplicationController
   private
 
   def find_experience_params_class(params)
-    binding.pry
     case params[:class]
     when 'category'
       @category = Category.find_by(search: params[:name])
@@ -35,15 +34,16 @@ class ExperiencesController < ApplicationController
       end
     when 'genre'
       @genre = Genre.find_by(search: params[:name])
-      @experiences = @genre.experiences
+      @genre.experiences.includes([:favorites, :area]).each do |exp|
+        @experiences << exp
+      end
     when 'area'
       @area = Area.find_by(search: params[:name])
-      @experiences = @area.experiences
+      @area.experiences.includes([:favorites, :genre]).each do |exp|
+        @experiences << exp
+      end
     end
     # アクティビティを'お気に入り'の多い順に配列を並び替え。
     @experiences.sort_by! { |exp| exp.favorites.length }.reverse!
-  end
-  Area.find_by(search: params[:name]).find_each do |area|
-    Experience.includes([:favorites, :genre, :area]).where(area_id: area.id).find_each { |exp| @experiences << exp}
   end
 end

--- a/app/views/experiences/activity.html.haml
+++ b/app/views/experiences/activity.html.haml
@@ -18,11 +18,12 @@
 .content_main
   .content_main_left
     .content_main_left_header
-      %div{id: 'category_icon'}
-      %h1.content_title
-        - if @category
+      - if @category
+        %div{id: 'category_icon'}
+        %h1.content_title
           = "#{@category.name}スポット"
-        -else
+      -else
+        %h1.content_title
           = "#{@island.name}のスポット"
     .content_main_left_info
       .content_main_left_info_up

--- a/app/views/experiences/activity.html.haml
+++ b/app/views/experiences/activity.html.haml
@@ -10,11 +10,21 @@
         = @category.name
       %span{id: 'category_id', style: 'display:none'}
         = @category.id
-    -else
+    - elsif @island
       %strong
         = @island.name
       %span{id: 'category_id', style: 'display:none'}
         = @island.id
+    - elsif @area
+      %strong
+        = @area.name
+      %span{id: 'category_id', style: 'display:none'}
+        = @area.id
+    - elsif @genre
+      %strong
+        = @genre.name
+      %span{id: 'category_id', style: 'display:none'}
+        = @genre.id
 .content_main
   .content_main_left
     .content_main_left_header
@@ -22,9 +32,15 @@
         %div{id: 'category_icon'}
         %h1.content_title
           = "#{@category.name}スポット"
-      -else
+      - elsif @island
         %h1.content_title
           = "#{@island.name}のスポット"
+      - elsif @area
+        %h1.content_title
+          = "#{@area.name}のスポット"
+      - elsif @genre
+        %h1.content_title
+          = "#{@genre.name}のスポット"
     .content_main_left_info
       .content_main_left_info_up
         %ul.ul_number

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -38,15 +38,15 @@
           %li.black
           -# アクティビティのエリア・ジャンルを表示させる。
           %li.area_wrapper
-            %span.area
+            %span.area_name
               エリア
             = link_to "#{@experience.area.island.name}", "/#{@experience.area.island.search}", class: 'island search_btn link_to change_link', method: :post
-            = link_to "#{@experience.area.name}","/#{@experience.area.search}", class: 'area serch_btn link_to change_link', method: :post
+            = link_to "#{@experience.area.name}","/#{@experience.area.search}", class: 'area search_btn link_to change_link', method: :post
           %li.genre_wrapper
-            %span.genre
+            %span.genre_name
               ジャンル
             = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to change_link', method: :post
-            = link_to "#{@experience.genre.name}", "/#{@experience.genre.search}", class: 'link_to change_link', method: :post
+            = link_to "#{@experience.genre.name}", "/#{@experience.genre.search}", class: 'genre search_btn link_to change_link', method: :post
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
         - if user_signed_in?

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -41,12 +41,12 @@
             %span.area
               エリア
             = link_to "#{@experience.area.island.name}", "/#{@experience.area.island.search}", class: 'island search_btn link_to change_link', method: :post
-            = link_to "#{@experience.area.name}",'#', class: 'link_to change_link'
+            = link_to "#{@experience.area.name}","/#{@experience.area.search}", class: 'area serch_btn link_to change_link', method: :post
           %li.genre_wrapper
             %span.genre
               ジャンル
             = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to change_link', method: :post
-            = link_to "#{@experience.genre.name}",'#', class: 'link_to change_link'
+            = link_to "#{@experience.genre.name}", "/#{@experience.genre.search}", class: 'link_to change_link', method: :post
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
         - if user_signed_in?

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -70,9 +70,9 @@
       - if controller_name == 'experiences'
         = render partial: 'shared/activity_info', locals: { exp: @experience }
       - elsif controller_name == 'reviews' && action_name == 'index'
-        = render partial: 'shared/activity_reviews', locals: { exp: @experiences, reviews: @reviews }
+        = render partial: 'shared/activity_reviews', locals: { exp: @experience, reviews: @reviews }
       - elsif controller_name == 'reviews' && action_name == 'edit'
-        = render partial: 'shared/activity_photos', locals: { exp: @experiences, images: @images }
+        = render partial: 'shared/activity_photos', locals: { exp: @experience, images: @images }
       -# コントローラー名とアクション名によって、表示するテンプレートを変更する。
   .show_content_right
 .footer

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -4,7 +4,7 @@
   = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
-  = link_to "#{@experience.genre.category.name}", '/shopping', class: 'category search_btn link_to change_link', style: 'color: blue', method: :post
+  = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to change_link', style: 'color: blue', method: :post
   %span
     &nbsp;>&nbsp;
   %strong
@@ -40,12 +40,12 @@
           %li.area_wrapper
             %span.area
               エリア
-            = link_to "#{@experience.area.island.name}",'#', class: 'link_to change_link'
+            = link_to "#{@experience.area.island.name}", "/#{@experience.area.island.search}", class: 'island search_btn link_to change_link', method: :post
             = link_to "#{@experience.area.name}",'#', class: 'link_to change_link'
           %li.genre_wrapper
             %span.genre
               ジャンル
-            = link_to "#{@experience.genre.category.name}", '/shopping', class: 'category search_btn link_to change_link', method: :post
+            = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to change_link', method: :post
             = link_to "#{@experience.genre.name}",'#', class: 'link_to change_link'
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。

--- a/db/migrate/20201201082805_add_column_areas_genres.rb
+++ b/db/migrate/20201201082805_add_column_areas_genres.rb
@@ -1,0 +1,7 @@
+class AddColumnAreasGenres < ActiveRecord::Migration[6.0]
+  def change
+    add_column :areas, :search, :string
+
+    add_column :genres, :search, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,145 +10,124 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_201_113_110_951) do
-  create_table 'active_storage_attachments',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index %w[blob_id], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id],
-            name: 'index_active_storage_attachments_uniqueness', unique: true
+ActiveRecord::Schema.define(version: 2020_12_01_082805) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table 'active_storage_blobs',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.bigint 'byte_size', null: false
-    t.string 'checksum', null: false
-    t.datetime 'created_at', null: false
-    t.index %w[key], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'areas',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'name', default: '', null: false
-    t.integer 'island_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.integer "island_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "search"
   end
 
-  create_table 'experiences',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'name', default: '', null: false
-    t.text 'outline'
-    t.string 'address', null: false
-    t.float 'latitude', limit: 53, null: false
-    t.float 'longitude', limit: 53, null: false
-    t.string 'business_hours_start'
-    t.string 'business_hours_finish'
-    t.bigint 'area_id', null: false
-    t.bigint 'genre_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.float 'score'
-    t.index %w[area_id], name: 'index_experiences_on_area_id'
-    t.index %w[genre_id], name: 'index_experiences_on_genre_id'
+  create_table "experiences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.text "outline"
+    t.string "address", null: false
+    t.float "latitude", limit: 53, null: false
+    t.float "longitude", limit: 53, null: false
+    t.string "business_hours_start"
+    t.string "business_hours_finish"
+    t.bigint "area_id", null: false
+    t.bigint "genre_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.float "score"
+    t.index ["area_id"], name: "index_experiences_on_area_id"
+    t.index ["genre_id"], name: "index_experiences_on_genre_id"
   end
 
-  create_table 'favorites',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'experience_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[experience_id], name: 'index_favorites_on_experience_id'
-    t.index %w[user_id], name: 'index_favorites_on_user_id'
+  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "experience_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["experience_id"], name: "index_favorites_on_experience_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
-  create_table 'genres',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'name', default: '', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'category_id', null: false
+  create_table "genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "category_id", null: false
+    t.string "search"
   end
 
-  create_table 'histories',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'experience_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[experience_id], name: 'index_histories_on_experience_id'
-    t.index %w[user_id], name: 'index_histories_on_user_id'
+  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "experience_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["experience_id"], name: "index_histories_on_experience_id"
+    t.index ["user_id"], name: "index_histories_on_user_id"
   end
 
-  create_table 'reviews',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.text 'comment', null: false
-    t.integer 'score', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'experience_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'title', null: false
-    t.index %w[experience_id], name: 'index_reviews_on_experience_id'
-    t.index %w[user_id], name: 'index_reviews_on_user_id'
+  create_table "reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "comment", null: false
+    t.integer "score", null: false
+    t.bigint "user_id", null: false
+    t.bigint "experience_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "title", null: false
+    t.index ["experience_id"], name: "index_reviews_on_experience_id"
+    t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
-  create_table 'sns_credentials',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'provider'
-    t.string 'uid'
-    t.bigint 'user_id'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[user_id], name: 'index_sns_credentials_on_user_id'
+  create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
   end
 
-  create_table 'users',
-               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8',
-               force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', default: '', null: false
-    t.text 'introduce'
-    t.integer 'admin'
-    t.index %w[email], name: 'index_users_on_email', unique: true
-    t.index %w[reset_password_token],
-            name: 'index_users_on_reset_password_token', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", default: "", null: false
+    t.text "introduce"
+    t.integer "admin"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key 'active_storage_attachments',
-                  'active_storage_blobs',
-                  column: 'blob_id'
-  add_foreign_key 'experiences', 'areas'
-  add_foreign_key 'experiences', 'genres'
-  add_foreign_key 'favorites', 'experiences'
-  add_foreign_key 'favorites', 'users'
-  add_foreign_key 'histories', 'experiences'
-  add_foreign_key 'histories', 'users'
-  add_foreign_key 'reviews', 'experiences'
-  add_foreign_key 'reviews', 'users'
-  add_foreign_key 'sns_credentials', 'users'
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "experiences", "areas"
+  add_foreign_key "experiences", "genres"
+  add_foreign_key "favorites", "experiences"
+  add_foreign_key "favorites", "users"
+  add_foreign_key "histories", "experiences"
+  add_foreign_key "histories", "users"
+  add_foreign_key "reviews", "experiences"
+  add_foreign_key "reviews", "users"
+  add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
## 概要
* アクティビティ詳細ページでの`エリア・ジャンル検索`ボタンが実装されていなかったので、実装することで地区ごと・ジャンルごとにアクティビティを検索できる様にする。

## 変更点
* `Areaモデル`と`Genreモデル`に検索用の`searchカラム`を追加。
* `experiencesコントローラー`内のアクティビティ検索用メソッドに、エリアとジャンルで検索した場合のコードを記述。

## テスト結果とテスト項目
- [x] アクティビティ詳細ページの`エリア・ジャンル検索ボタン`をクリックすることで、そのアクティビティが属しているエリア又はジャンルでのアクティビティ検索ができる。

## Issue番号
close #72 