### PR TITLE
エリア・ジャンル検索時の5段階評価表示実装

### DIFF
--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -1,6 +1,7 @@
 "use strict";
 
 $(window).on("load", function () {
+  console.log();
   const categoryIcons = [
     "hotel_icon",
     "lunch_icon",
@@ -10,22 +11,30 @@ $(window).on("load", function () {
     "shopping_icon",
   ];
   const url = location.pathname;
-  const conditions =
-    url == "/shopping" ||
-    url == "/landmark" ||
-    url == "/leisure" ||
-    url == "/rentacar" ||
-    url == "/dinner" ||
-    url == "/hotel" ||
-    url == "/niihau" ||
-    url == "/kauai" ||
-    url == "/oahu" ||
-    url == "/molokai" ||
-    url == "/lanai" ||
-    url == "/kahoolawe" ||
-    url == "/maui" ||
-    url == "/hawaii" ||
-    /\/experiences\/[0-9]{1,}/.test(url);
+  const starRatingTarget = [
+    "/shopping",
+    "/landmark",
+    "/leisure",
+    "/rentacar",
+    "/dinner",
+    "/hotel",
+    "/niihau",
+    "/kauai",
+    "/oahu",
+    "/molokai",
+    "/lanai",
+    "/kahoolawe",
+    "/maui",
+    "/hawaii",
+    "/restaurant",
+    "/card-shop",
+    "/aquarium",
+    "/convenience-store",
+    "/honolulu"
+  ];
+  // URLの中に配列に入っているパスが入っていれば、カテゴリーアイコンと5段階評価の表示を適用する。
+  const conditions = $.inArray(url, starRatingTarget) !== -1 || /\/experiences\/[0-9]{1,}/.test(url)
+  $.inArray(url, starRatingTarget) !== -1 || /\/experiences\/[0-9]{1,}/.test(url);
   if (conditions) {
     // 'category_id'を取得して、その'id'に対応したアイコン画像用のクラスを配列から取得して追加させる。
     const categoryIcon = $("#category_icon");

--- a/app/views/shared/_leh_header.html.haml
+++ b/app/views/shared/_leh_header.html.haml
@@ -11,11 +11,11 @@
             -# ユーザーがログインしていなければ『ログイン』か『会員登録』を表示させる。
             - unless user_signed_in?
               %li
-                = link_to 'ログイン', new_user_session_path, rel: 'nofollow', class: 'sl_name'
+                = link_to 'ログイン', new_user_session_path, rel: 'nofollow', class: 'sl_name change_link'
               %li
-                = link_to '会員登録', new_user_registration_path, rel: 'nofollow', class: 'sl_name'
+                = link_to '会員登録', new_user_registration_path, rel: 'nofollow', class: 'sl_name change_link'
             - else
               %li
-                = link_to "#{current_user.name}さんのマイページ", "/users/#{current_user.id}", rel: 'nofollow', class: 'sl_name'
+                = link_to "#{current_user.name}さんのマイページ", "/users/#{current_user.id}", rel: 'nofollow', class: 'sl_name change_link'
               %li
-                = link_to 'ログアウト', destroy_user_session_path, method: :delete, rel: 'nofollow', class: 'sl_name'
+                = link_to 'ログアウト', destroy_user_session_path, method: :delete, rel: 'nofollow', class: 'sl_name change_link'


### PR DESCRIPTION
## 概要
* `エリア・ジャンル検索`の際にアクティビティの5段階評価の表示用関数が適用されていないので、適用できる様にコードを修正する。

## 変更点
* `search.js`内のURL判定用の配列を用意し、配列内に適用させたいページのパスを格納。
* 関数を適用させるための条件を、配列内にURLのパス部分があるかどうかで判定する様にコード変更。

## テスト結果とテスト項目
- [x] `エリア・ジャンル検索`をした際にも、各アクティビティの5段階評価の表示が評価点に対応した表示になっている。

## Issue番号
close #76 