### PR TITLE
キーワード検索時の不具合解決

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :search_experiences
 
   private
 
   def search_experiences
     @search = Experience.ransack(params[:q])
-    @experiences = @search.result
   end
 
   def redirect_experience(experience_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,9 @@ class ApplicationController < ActionController::Base
   def find_exp_id(exp_id)
     @experience = Experience.find(exp_id)
   end
+
+  # アクティビティを'お気に入り'の多い順に配列を並び替え。
+  def exps_sort(exps)
+    exps.sort_by! { |exp| exp.favorites.length }.reverse!
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,6 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def search_experiences
-    @search = Experience.ransack(params[:q])
-  end
-
   def redirect_experience(experience_id)
     redirect_to "/experiences/#{experience_id}"
   end

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class ExperiencesController < ApplicationController
-  before_action :search_experiences, only: :search
-
-  def search
-    @experiences = @search.result
-  end
 
   def show
+    binding.pry
     @experience = Experience.find(params[:id])
     # ハッシュ形式で各評価点がいくつあるかを格納する。
     @scores = @experience.reviews.group(:score).count

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -43,7 +43,6 @@ class ExperiencesController < ApplicationController
         @experiences << exp
       end
     end
-    # アクティビティを'お気に入り'の多い順に配列を並び替え。
-    @experiences.sort_by! { |exp| exp.favorites.length }.reverse!
+    exps_sort(@experiences)
   end
 end

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class ExperiencesController < ApplicationController
-  def search; end
+  before_action :search_experiences, only: :search
+
+  def search
+    @experiences = @search.result
+  end
 
   def show
     @experience = Experience.find(params[:id])

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -3,7 +3,6 @@
 class ExperiencesController < ApplicationController
 
   def show
-    binding.pry
     @experience = Experience.find(params[:id])
     # ハッシュ形式で各評価点がいくつあるかを格納する。
     @scores = @experience.reviews.group(:score).count

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -6,8 +6,8 @@ class TopsController < ApplicationController
   def index; end
 
   def search
-    @experiences = @search.result
-    binding.pry
+    @experiences = @search.result.includes([:favorites, :genre, :area])
+    render 'experiences/activity'
   end
 
   private

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class TopsController < ApplicationController
+  before_action :search_experiences
+
   def index; end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -13,7 +13,6 @@ class TopsController < ApplicationController
     exps_sort(@experiences)
     # 検索ワード
     @search_word = params[:q][:name_cont]
-    # binding.pry
     render 'experiences/activity'
   end
 

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -4,4 +4,15 @@ class TopsController < ApplicationController
   before_action :search_experiences
 
   def index; end
+
+  def search
+    @experiences = @search.result
+    binding.pry
+  end
+
+  private
+
+  def search_experiences
+    @search = Experience.ransack(params[:q])
+  end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -7,6 +7,9 @@ class TopsController < ApplicationController
 
   def search
     @experiences = @search.result.includes([:favorites, :genre, :area])
+    # 検索ワード
+    @search_word = params[:q][:name_cont]
+    # binding.pry
     render 'experiences/activity'
   end
 

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -6,7 +6,11 @@ class TopsController < ApplicationController
   def index; end
 
   def search
-    @experiences = @search.result.includes([:favorites, :genre, :area])
+    @experiences = []
+    @search.result.includes([:favorites, :genre, :area]).each do |result|
+      @experiences << result
+    end
+    exps_sort(@experiences)
     # 検索ワード
     @search_word = params[:q][:name_cont]
     # binding.pry

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -34,14 +34,13 @@ $(window).on("load", function () {
   ];
   // URLの中に配列に入っているパスが入っていれば、カテゴリーアイコンと5段階評価の表示を適用する。
   const conditions = $.inArray(url, starRatingTarget) !== -1 || /\/experiences\/[0-9]{1,}/.test(url)
-  $.inArray(url, starRatingTarget) !== -1 || /\/experiences\/[0-9]{1,}/.test(url);
   if (conditions) {
     // 'category_id'を取得して、その'id'に対応したアイコン画像用のクラスを配列から取得して追加させる。
     const categoryIcon = $("#category_icon");
     const categoryId = $("#category_id")[0].innerText;
     categoryIcon.addClass(`${categoryIcons[categoryId - 1]}`);
   }
-  if (conditions) {
+  if (conditions || /\/search/) {
     // exp_scoreクラスを複数取得して、ノードリストから配列へ変換し、各要素毎に処理をしていく。
     const expScoreArray = Array.from($(".exp_score"));
     expScoreArray.forEach((element, index) => {

--- a/app/views/experiences/activity.html.haml
+++ b/app/views/experiences/activity.html.haml
@@ -9,19 +9,7 @@
 .content_main
   .content_main_left
     .content_main_left_header
-      - if @category
-        %div{id: 'category_icon'}
-        %h1.content_title
-          = "#{@category.name}スポット"
-      - elsif @island
-        %h1.content_title
-          = "#{@island.name}のスポット"
-      - elsif @area
-        %h1.content_title
-          = "#{@area.name}のスポット"
-      - elsif @genre
-        %h1.content_title
-          = "#{@genre.name}のスポット"
+      = render 'shared/spot_name'
     .content_main_left_info
       .content_main_left_info_up
         %ul.ul_number

--- a/app/views/experiences/activity.html.haml
+++ b/app/views/experiences/activity.html.haml
@@ -5,26 +5,7 @@
     = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
     %span
       &nbsp;>&nbsp;
-    - if @category
-      %strong
-        = @category.name
-      %span{id: 'category_id', style: 'display:none'}
-        = @category.id
-    - elsif @island
-      %strong
-        = @island.name
-      %span{id: 'category_id', style: 'display:none'}
-        = @island.id
-    - elsif @area
-      %strong
-        = @area.name
-      %span{id: 'category_id', style: 'display:none'}
-        = @area.id
-    - elsif @genre
-      %strong
-        = @genre.name
-      %span{id: 'category_id', style: 'display:none'}
-        = @genre.id
+    = render 'shared/transition_destination'
 .content_main
   .content_main_left
     .content_main_left_header

--- a/app/views/shared/_spot_name.html.haml
+++ b/app/views/shared/_spot_name.html.haml
@@ -1,0 +1,16 @@
+- if @category
+  %div{id: 'category_icon'}
+  %h1.content_title
+    = "#{@category.name}スポット"
+- elsif @island
+  %h1.content_title
+    = "#{@island.name}のスポット"
+- elsif @area
+  %h1.content_title
+    = "#{@area.name}のスポット"
+- elsif @genre
+  %h1.content_title
+    = "#{@genre.name}のスポット"
+- elsif @search_word
+  %h1.content_title
+    = "'#{@search_word}' が含まれるスポット"

--- a/app/views/shared/_transition_destination.html.haml
+++ b/app/views/shared/_transition_destination.html.haml
@@ -18,3 +18,6 @@
     = @genre.name
   %span{id: 'category_id', style: 'display:none'}
     = @genre.id
+- elsif @search_word
+  %strong
+    = "'#{@search_word}' の検索結果"

--- a/app/views/shared/_transition_destination.html.haml
+++ b/app/views/shared/_transition_destination.html.haml
@@ -1,0 +1,20 @@
+- if @category
+  %strong
+    = @category.name
+  %span{id: 'category_id', style: 'display:none'}
+    = @category.id
+- elsif @island
+  %strong
+    = @island.name
+  %span{id: 'category_id', style: 'display:none'}
+    = @island.id
+- elsif @area
+  %strong
+    = @area.name
+  %span{id: 'category_id', style: 'display:none'}
+    = @area.id
+- elsif @genre
+  %strong
+    = @genre.name
+  %span{id: 'category_id', style: 'display:none'}
+    = @genre.id

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -49,7 +49,7 @@
         .search_word_header_string
           %b キーワードから探す
       .search_word_main
-        = search_form_for @search, url: experiences_search_path, class: 'form' do |form|
+        = search_form_for @search, url: tops_search_path, class: 'form' do |form|
           .keyword
             = form.label :name_cont, 'キーワード', class: 'main_word', style: 'font-weight: bold;'
             = form.search_field :name_cont, placeholder: 'ホテル名・地名やイベント名など', class: 'text_field'

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -49,7 +49,7 @@
         .search_word_header_string
           %b キーワードから探す
       .search_word_main
-        = search_form_for @search, url: tops_search_path, class: 'form' do |form|
+        = search_form_for @search, url: search_path, class: 'form' do |form|
           .keyword
             = form.label :name_cont, 'キーワード', class: 'main_word', style: 'font-weight: bold;'
             = form.search_field :name_cont, placeholder: 'ホテル名・地名やイベント名など', class: 'text_field'

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -51,10 +51,10 @@
       .search_word_main
         = search_form_for @search, url: experiences_search_path, class: 'form' do |form|
           .keyword
-            %b.main_word キーワード
+            = form.label :name_cont, 'キーワード', class: 'main_word', style: 'font-weight: bold;'
             = form.search_field :name_cont, placeholder: 'ホテル名・地名やイベント名など', class: 'text_field'
           .select
-            %b.main_select 評価
+            = form.label :score_gteq, '評価', class: 'main_select', style: 'font-weight: bold;'
             = form.collection_select :score_gteq, Score.all, :id, :name, {}, {class:'select_box', id:'score'}
           = form.submit '検索', class: 'submit'
   .search_right

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     resource :histories, only: %i[create destroy]
     resource :favorites, only: %i[create destroy]
   end
-  get 'experiences/search'
+  get 'tops/search'
   post '/:name', to: 'experiences#edit'
   get '/experiences/:experience_id/photos', to: 'reviews#edit'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     resource :histories, only: %i[create destroy]
     resource :favorites, only: %i[create destroy]
   end
-  get 'tops/search'
+  get '/search', to: 'tops#search'
   post '/:name', to: 'experiences#edit'
   get '/experiences/:experience_id/photos', to: 'reviews#edit'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,7 @@ Rails.application.routes.draw do
     resource :histories, only: %i[create destroy]
     resource :favorites, only: %i[create destroy]
   end
-  namespace :experiences do
-    get 'search'
-  end
+  get 'experiences/search'
   post '/:name', to: 'experiences#edit'
   get '/experiences/:experience_id/photos', to: 'reviews#edit'
 end


### PR DESCRIPTION
## 概要
* トップページの`キーワード検索`を実行した際に、エラーが発生して検索ができなくなっていたので、原因を究明及び解決する。

## 変更点
* `キーワード検索フォーム`のあるページと`キーワード検索結果ページ`が別コントローラーでエラーが発生していたと思われる為、`searchアクション`を`experienceコントローラー`から`topsコントローラー`へ移動。
* `tops#search`がリクエストされた際に、レスポンスとしてrenderメソッドで`experineces/activity.html.haml`のビューファイルを返す様にコード記述。
* `キーワード検索`でもお気に入り数が多い順にアクティビティを並び替える為、`applicationコントローラー`にアクティビティ並び替え用メソッドを切り出し、`topsコントローラー`と`experiencesコントローラー`にメソッドを呼び出す様にコードを修正。

## テスト結果とテスト項目
- [x] キーワード検索をした際に、エラー画面へ行かずにキーワードと評価点での検索結果ページに遷移する。
- [x] キーワード検索結果ページに遷移した際に、アクティビティがお気に入り数が多い順になる様表示されている。

## Issue番号
close #80 