### PR TITLE
他人のお気に入り一覧ページに遷移できない様修正

### DIFF
--- a/app/assets/stylesheets/pages/_mypage.scss
+++ b/app/assets/stylesheets/pages/_mypage.scss
@@ -130,6 +130,10 @@ $userNameHeight: calc(100% / 4 * 3);
             font-size: 12px;
             border-bottom: 1px dotted black;
             width: 100%;
+            .mypage_top:hover{
+              text-decoration-line: underline;
+              color: #ffa500;
+            }
           }
           .edit_user{
             padding-top: 17px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,13 +10,13 @@ class ApplicationController < ActionController::Base
       if current_user.id == params[:id].to_i
         find_user_show
       else
-        redirect_to
+        redirect_to root_path
       end
     else
       if current_user.id == params[:user_id].to_i
         find_user_show
       else
-        redirect_to
+        redirect_to root_path
       end
     end
   end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class FavoritesController < ApplicationController
+  before_action :authenticate_user!, only: %i[index create destroy update]
 
   def index
     @favorites = Favorite.includes([{experience: :favorites}, {experience: :area}]).where(user_id: current_user.id).order('created_at DESC')

--- a/app/views/shared/_mypage_main_contents.html.haml
+++ b/app/views/shared/_mypage_main_contents.html.haml
@@ -20,7 +20,7 @@
   .mypage_contents_main_right
     .user_edit_main
       .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-        = link_to 'マイページトップ', "/users/#{current_user.id}"
+        = link_to 'マイページトップ', "/users/#{current_user.id}", class: 'mypage_top'
         &nbsp;>&nbsp;
         %strong 会員情報の確認・変更
       = form_with model: user, url: user_registration_path, local: true, class: 'edit_user' do |f|
@@ -44,7 +44,7 @@
   .mypage_contents_main_right
     .user_favorites_main
       %div.menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-        = link_to 'マイページトップ', "/users/#{current_user.id}"
+        = link_to 'マイページトップ', "/users/#{current_user.id}", class: 'mypage_top'
         &nbsp;>&nbsp;
         %strong お気に入りした場所
       .favorites_activity_show_area


### PR DESCRIPTION
## 概要
* 他人のお気に入り一覧ページに遷移しようとURLを入力した際に、そのまま遷移できてしまっていたため、他人のページに遷移しない様にコードを修正する。

## 変更点
* `favoritesコントローラー`にbefore_actionでログインユーザー以外は新規登録画面に遷移する様にコードを追記。
* `applicationコントローラー`内で他人のユーザーページに遷移しようとした場合は、トップページにリダイレクトされる様にメソッドに追記。

## テスト結果とテスト項目
- [x] 未ログインユーザーが他人のお気に入り一覧ページに遷移しようとすると、新規登録画面にリダイレクトされる。
- [x] 他人のお気に入り一覧ページに遷移しようとすると、トップページにリダイレクトされる。

## Issue番号
close #84 