### PR TITLE
リンクボタン表示色変更方法をcssの擬似クラスに変更

### DIFF
--- a/app/assets/stylesheets/pages/_mypage.scss
+++ b/app/assets/stylesheets/pages/_mypage.scss
@@ -130,10 +130,6 @@ $userNameHeight: calc(100% / 4 * 3);
             font-size: 12px;
             border-bottom: 1px dotted black;
             width: 100%;
-            .mypage_top:hover{
-              text-decoration-line: underline;
-              color: #ffa500;
-            }
           }
           .edit_user{
             padding-top: 17px;

--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -81,8 +81,8 @@ $regHeight: 881px;
                     }
                   }
                   .password_reset{
-                    color: #008dde!important;
-                    text-decoration: none!important;
+                    color: #008dde;
+                    text-decoration: none;
                   }
                 .signin_up_button{
                   width: $v100;
@@ -134,8 +134,8 @@ $regHeight: 881px;
               margin: 10px 0 0;
               font-size: 11px;
               .register_policy_link{
-                color: #008dde!important;
-                text-decoration: none!important;
+                color: #008dde;
+                text-decoration: none;
               }
             }
             .testuser_sign_in_form{
@@ -168,8 +168,8 @@ $regHeight: 881px;
                 margin-right: 5px;
               }
               .login_text{
-                color: #008dde!important;
-                text-decoration: none!important;
+                color: #008dde;
+                text-decoration: none;
                 text-align: center;
                 display: block;
               }

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -245,7 +245,7 @@ img {
   color: blue;
 }
 
-.link_hover {
+.link_hover:hover {
   text-decoration-line: underline !important;
   color: #ffa500 !important;
 }

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -250,7 +250,7 @@ img {
   color: #ffa500 !important;
 }
 
-.btn_hover {
+.btn_hover:hover {
   background-color: #ffa500 !important;
 }
 

--- a/app/assets/stylesheets/pages/_versatility.scss
+++ b/app/assets/stylesheets/pages/_versatility.scss
@@ -242,11 +242,15 @@ img {
 }
 
 .link_to {
-  color: blue;
+  color: #069;
 }
 
 .link_hover:hover {
   text-decoration-line: underline !important;
+  color: #ffa500 !important;
+}
+
+.link_hover_not_underline:hover {
   color: #ffa500 !important;
 }
 

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -49,10 +49,10 @@ $(function () {
           return 1;
         }
       });
-      $(`#${sortName}_sort_${activeSortId}`).removeClass("active_sort").addClass("change_link");
+      $(`#${sortName}_sort_${activeSortId}`).removeClass("active_sort").addClass("link_hover");
       // 選択した並び順のID数値を再代入している。
       activeSortId = sortId;
-      $(this).addClass("active_sort").removeClass("change_link").removeClass("link_hover");
+      $(this).addClass("active_sort").removeClass("link_hover");
       $(`.${sortName}_list`).empty().append(sortList).addClass("active_fade");
       setTimeout(function () {
         $(`.${sortName}_list`).removeClass("active_fade");

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -61,10 +61,10 @@ $(window).on("load", function () {
 });
 
 $(function () {
-  // 'ボタン'にホバーすると表示色を変更させる。
-  $('[id^="btn"]').on("mouseover mouseout", function () {
-    $(this).toggleClass("btn_hover");
-  });
+  // // 'ボタン'にホバーすると表示色を変更させる。
+  // $('[id^="btn"]').on("mouseover mouseout", function () {
+  //   $(this).toggleClass("btn_hover");
+  // });
 
   // '目的別検索'か'島名別検索'なのかを判断するためのクラス名をパラメーターに追加するための関数。
   $('.search_btn').on('click', function(){

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -61,10 +61,10 @@ $(window).on("load", function () {
 });
 
 $(function () {
-  // 'id名'に'change'と入っている要素をホバーしている時だけリンクの表示を変更させる。
-  $(document).on("mouseover mouseout", '[class*="change_link"]', function () {
-    $(this).toggleClass("link_hover");
-  });
+  // // 'id名'に'change'と入っている要素をホバーしている時だけリンクの表示を変更させる。
+  // $(document).on("mouseover mouseout", '[class*="change_link"]', function () {
+  //   $(this).toggleClass("link_hover");
+  // });
   // 'ボタン'にホバーすると表示色を変更させる。
   $('[id^="btn"]').on("mouseover mouseout", function () {
     $(this).toggleClass("btn_hover");

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -61,10 +61,6 @@ $(window).on("load", function () {
 });
 
 $(function () {
-  // // 'id名'に'change'と入っている要素をホバーしている時だけリンクの表示を変更させる。
-  // $(document).on("mouseover mouseout", '[class*="change_link"]', function () {
-  //   $(this).toggleClass("link_hover");
-  // });
   // 'ボタン'にホバーすると表示色を変更させる。
   $('[id^="btn"]').on("mouseover mouseout", function () {
     $(this).toggleClass("btn_hover");

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -23,7 +23,7 @@
                         = f.check_box :remember_me
                       %span ログイン状態を保持
                     = link_to "パスワードをお忘れの方", new_password_path(resource_name), target: '_blank', rel: 'noopner', class: 'password_reset'
-                = f.submit "ログイン", class: 'button_cv signin_up_button'
+                = f.submit "ログイン", class: 'button_cv signin_up_button btn_hover'
               / 入力フォーム
             .social_login
               %span{class: 'social_login_title'}こちらもご利用いただけます
@@ -39,7 +39,7 @@
                   %a{href: '#', class: 'social_login_link'}
               / SNSアカウントでログインできる
               = render "devise/shared/links"
-              / テストユーザーとしてログインするためのフォーム 
+              / テストユーザーとしてログインするためのフォーム
               .testuser_sign_in_form
                 %span.testuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
                 = form_with model: @user, url: user_session_path, local: true, class: 'testuser_login_form' do |f|

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -22,7 +22,7 @@
                       %span{'aria-checked' => "true", class: 'checkbox_wrapper'}
                         = f.check_box :remember_me
                       %span ログイン状態を保持
-                    = link_to "パスワードをお忘れの方", new_password_path(resource_name), target: '_blank', rel: 'noopner', class: 'password_reset'
+                    = link_to "パスワードをお忘れの方", new_password_path(resource_name), target: '_blank', rel: 'noopner', class: 'password_reset link_hover_not_underline'
                 = f.submit "ログイン", class: 'button_cv signin_up_button btn_hover'
               / 入力フォーム
             .social_login
@@ -45,7 +45,7 @@
                 = form_with model: @user, url: user_session_path, local: true, class: 'testuser_login_form' do |f|
                   = f.hidden_field :email, :value => 'test@test.com'
                   = f.hidden_field :password, :value => 'testuser1'
-                  = f.submit "こちら", class: 'testuser_login_button'
+                  = f.submit "こちら", class: 'testuser_login_button link_hover_not_underline'
               / テストユーザーとしてログインするためのフォーム
       / フッター
       .signin_up_footer

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -2,13 +2,13 @@
   %p.login_link
     %span.login_link_title
       すでにアカウントをお持ちですか？
-    = link_to "ログイン", new_session_path(resource_name), class: 'login_text'
+    = link_to "ログイン", new_session_path(resource_name), class: 'login_text link_hover_not_underline'
     %br/
 - if devise_mapping.registerable? && controller_name != 'registrations' && controller_name != 'omniauth_callbacks'
   %p.login_link_wrapper
     %span.login_link_title
       アカウントをお持ちではありませんか？
-    = link_to "会員登録", new_registration_path(resource_name), class: 'login_text'
+    = link_to "会員登録", new_registration_path(resource_name), class: 'login_text link_hover_not_underline'
     %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
@@ -16,4 +16,3 @@
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
   = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
   %br/
-

--- a/app/views/experiences/activity.html.haml
+++ b/app/views/experiences/activity.html.haml
@@ -2,7 +2,7 @@
   = render 'shared/leh_header'
 .content_header
   .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-    = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
+    = link_to 'トップページ', root_path, class: 'link_hover', style: 'color: blue'
     %span
       &nbsp;>&nbsp;
     = render 'shared/transition_destination'
@@ -26,7 +26,7 @@
         %ul.order
           %li
             並び順：
-          %li{id: 'experience_sort_1', class: 'sort_link change_link'}
+          %li{id: 'experience_sort_1', class: 'sort_link link_hover'}
             口コミランク順
           %li{id: 'experience_sort_2', class: 'sort_link active_sort'}
             おすすめ順
@@ -35,7 +35,7 @@
         %li.content_main_left_main_list
           .content_main_header
             .content_main_header_name
-              = link_to "#{exp.name}", "experiences/#{exp.id}", class: 'show_experiences change_link'
+              = link_to "#{exp.name}", "experiences/#{exp.id}", class: 'show_experiences link_hover'
             .experience_score
               .star_rating
                 %div{id: "star_rating#{index}", class: 'star_rating_front'}
@@ -46,7 +46,7 @@
                 = exp.score
               %span.review_count
                 （
-              = link_to "口コミ#{exp.reviews.count.to_s(:delimited)}件", experience_reviews_path(exp.id), class: 'change_link review_count review_link'
+              = link_to "口コミ#{exp.reviews.count.to_s(:delimited)}件", experience_reviews_path(exp.id), class: 'link_hover review_count review_link'
               %span.review_count
                 ）
             %p.content_main_header_place
@@ -74,7 +74,7 @@
         -#   最近のお気に入りスポット
         -# .right_content
         -#   = image_tag '', height: '38px', width: '51px', class: 'fav_image'
-        -#   %p{class: 'fav_name change_link'}
+        -#   %p{class: 'fav_name link_hover'}
         -#     テスト
         -# .content_sub
         -#   = image_tag '', height: '38px', width: '51px', class: 'fav_image'

--- a/app/views/experiences/show.html.haml
+++ b/app/views/experiences/show.html.haml
@@ -1,10 +1,10 @@
 .header
   = render 'shared/leh_header'
 .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-  = link_to 'トップページ', root_path, class: 'change_link', style: 'color: blue'
+  = link_to 'トップページ', root_path, class: 'link_hover', style: 'color: blue'
   %span
     &nbsp;>&nbsp;
-  = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to change_link', style: 'color: blue', method: :post
+  = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to link_hover', style: 'color: blue', method: :post
   %span
     &nbsp;>&nbsp;
   %strong
@@ -32,7 +32,7 @@
               = @experience.score
             %span.review_count
               （
-            = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", experience_reviews_path(@experience.id), class: 'change_link review_count review_link', data:{name: 'review_count'}
+            = link_to "口コミ#{@experience.reviews.count.to_s(:delimited)}件", experience_reviews_path(@experience.id), class: 'link_hover review_count review_link', data:{name: 'review_count'}
             %span.review_count
               ）
           %li.black
@@ -40,13 +40,13 @@
           %li.area_wrapper
             %span.area_name
               エリア
-            = link_to "#{@experience.area.island.name}", "/#{@experience.area.island.search}", class: 'island search_btn link_to change_link', method: :post
-            = link_to "#{@experience.area.name}","/#{@experience.area.search}", class: 'area search_btn link_to change_link', method: :post
+            = link_to "#{@experience.area.island.name}", "/#{@experience.area.island.search}", class: 'island search_btn link_to link_hover', method: :post
+            = link_to "#{@experience.area.name}","/#{@experience.area.search}", class: 'area search_btn link_to link_hover', method: :post
           %li.genre_wrapper
             %span.genre_name
               ジャンル
-            = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to change_link', method: :post
-            = link_to "#{@experience.genre.name}", "/#{@experience.genre.search}", class: 'genre search_btn link_to change_link', method: :post
+            = link_to "#{@experience.genre.category.name}", "/#{@experience.genre.category.search}", class: 'category search_btn link_to link_hover', method: :post
+            = link_to "#{@experience.genre.name}", "/#{@experience.genre.search}", class: 'genre search_btn link_to link_hover', method: :post
       .show_info_right
         -# 未ログインユーザーなら'口コミ投稿'等のボタンが表示されない。
         - if user_signed_in?

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -68,7 +68,7 @@
             %div{id: 'picture_show_area', class: 'picture_show_area'}
         .review_submit
           -# 送信ボタン
-          = f.submit "投稿する",id: 'btn', class: 'submit'
+          = f.submit "投稿する",id: 'btn', class: 'submit btn_hover'
   .review_old_show
 .footer
   = render 'shared/leh_footer'

--- a/app/views/shared/_activity_contents.html.haml
+++ b/app/views/shared/_activity_contents.html.haml
@@ -175,7 +175,7 @@
             並び替え
           %li{id: 'review_sort_2', class: 'sort_link active_sort'}
             投稿日順
-          %li{id: 'review_sort_1', class: 'sort_link change_link'}
+          %li{id: 'review_sort_1', class: 'sort_link link_hover'}
             評価順
       %ul.review_list
         -# 口コミの数だけ口コミ表示処理を繰り返す。

--- a/app/views/shared/_leh_header.html.haml
+++ b/app/views/shared/_leh_header.html.haml
@@ -11,11 +11,11 @@
             -# ユーザーがログインしていなければ『ログイン』か『会員登録』を表示させる。
             - unless user_signed_in?
               %li
-                = link_to 'ログイン', new_user_session_path, rel: 'nofollow', class: 'sl_name change_link'
+                = link_to 'ログイン', new_user_session_path, rel: 'nofollow', class: 'sl_name link_hover'
               %li
-                = link_to '会員登録', new_user_registration_path, rel: 'nofollow', class: 'sl_name change_link'
+                = link_to '会員登録', new_user_registration_path, rel: 'nofollow', class: 'sl_name link_hover'
             - else
               %li
-                = link_to "#{current_user.name}さんのマイページ", user_path(current_user.id), rel: 'nofollow', class: 'sl_name change_link'
+                = link_to "#{current_user.name}さんのマイページ", user_path(current_user.id), rel: 'nofollow', class: 'sl_name link_hover'
               %li
-                = link_to 'ログアウト', destroy_user_session_path, method: :delete, rel: 'nofollow', class: 'sl_name change_link'
+                = link_to 'ログアウト', destroy_user_session_path, method: :delete, rel: 'nofollow', class: 'sl_name link_hover'

--- a/app/views/shared/_mypage_main_contents.html.haml
+++ b/app/views/shared/_mypage_main_contents.html.haml
@@ -20,7 +20,7 @@
   .mypage_contents_main_right
     .user_edit_main
       .menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-        = link_to 'マイページトップ', "/users/#{current_user.id}", class: 'mypage_top'
+        = link_to 'マイページトップ', "/users/#{current_user.id}", class: 'link_hover'
         &nbsp;>&nbsp;
         %strong 会員情報の確認・変更
       = form_with model: user, url: user_registration_path, local: true, class: 'edit_user' do |f|
@@ -44,7 +44,7 @@
   .mypage_contents_main_right
     .user_favorites_main
       %div.menu{id: 'link_main', style: 'margin-bottom:0; text-align: left'}
-        = link_to 'マイページトップ', "/users/#{current_user.id}", class: 'mypage_top'
+        = link_to 'マイページトップ', "/users/#{current_user.id}", class: 'link_hover'
         &nbsp;>&nbsp;
         %strong お気に入りした場所
       .favorites_activity_show_area
@@ -65,7 +65,7 @@
               .activity_picture
                 = link_to "", experience_path(fav.experience.id), class: 'activity_picture_link'
               .activity_info_wrapper
-                = link_to "#{fav.experience.name}", experience_path(fav.experience.id), class: 'activity_name change_link'
+                = link_to "#{fav.experience.name}", experience_path(fav.experience.id), class: 'activity_name link_hover'
                 %p.activity_place
                   = "#{fav.experience.area.island.name} > #{fav.experience.area.name}"
                 %span.favorites_number

--- a/app/views/shared/_mypage_main_contents.html.haml
+++ b/app/views/shared/_mypage_main_contents.html.haml
@@ -38,7 +38,7 @@
           = f.label :image do
             = user_image_attached?(user)
           = f.file_field :image, class: 'hidden'
-        = f.submit "更新する", class: 'button_cv update_button'
+        = f.submit "更新する", class: 'button_cv update_button btn_hover'
 -# ユーザーのお気に入り登録済みアクティビティ一覧表示ページ
 - if controller_name == 'favorites' && action_name == 'index'
   .mypage_contents_main_right

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -56,7 +56,7 @@
           .select
             = form.label :score_gteq, '評価', class: 'main_select', style: 'font-weight: bold;'
             = form.collection_select :score_gteq, Score.all, :id, :name, {}, {class:'select_box', id:'score'}
-          = form.submit '検索', class: 'submit'
+          = form.submit '検索', class: 'submit btn_hover'
   .search_right
     .search_map
       .search_map_header

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -38,7 +38,7 @@
               / SNSアカウントでログインできる
             %p.register_policy
               会員登録に伴い、
-              %a{href: '#', class: 'register_policy_link'}プライバシーポリシー
+              %a{href: '#', class: 'register_policy_link link_hover_not_underline'}プライバシーポリシー
               に同意したものとみなされます。
               = render "devise/shared/links"
               / テストユーザーとしてログインするためのフォーム
@@ -47,7 +47,7 @@
                 = form_with model: @user, url: user_session_path, local: true, class: 'testuser_login_form' do |f|
                   = f.hidden_field :email, :value => 'test@test.com', id: 'test_user_email'
                   = f.hidden_field :password, :value => 'testuser1', id: 'test_user_password'
-                  = f.submit "こちら", class: 'testuser_login_button'
+                  = f.submit "こちら", class: 'testuser_login_button link_hover_not_underline'
               / テストユーザーとしてログインするためのフォーム
       / フッター
       .signin_up_footer

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -5,7 +5,6 @@
       .signin_up_main_wrapper
         .signin_up_main
           .signin_up_main_content
-            -# = render "devise/shared/error_messages", resource: @user
             %span.register_text 会員登録
             .signin_up_form
               / 入力フォーム
@@ -22,7 +21,7 @@
                     = f.password_field :password, placeholder: 'パスワード（8～20文字・半角英数字・記号を2種以上）', maxlength: '20', autocomplete: "new-password", class: 'signin_up_input'
                   .signin_up_form_input
                     = f.password_field :password_confirmation, placeholder: '上記と同じパスワードを入力してください', autocomplete: "new-password", class: 'signin_up_input'
-                = f.submit "登録する", id: 'btn', class: 'button_cv signin_up_button'
+                = f.submit "登録する", id: 'btn', class: 'button_cv signin_up_button btn_hover'
               / 入力フォーム
             .social_login
               %span{class: 'social_login_title'}こちらもご利用いただけます


### PR DESCRIPTION
## 概要
* `リンク・ボタン`の表示色変更方法がJSファイル内での関数な為、CSSの擬似クラスで変更する様にコードを修正する。

## 変更点
* `search.js`内に記述している表示色変更用クラスを付与する関数を削除し、`versatility.scss`内に擬似クラス(:hover)を付与する様にコードを修正。

## テスト結果とテスト項目
- [x] リンクやボタンをホバーした際に、表示色が変更される。

## Issue番号
close #86 