### PR TITLE
写真が投稿されていれば、写真一覧ページの表示がされる様にビューファイルを修正

### DIFF
--- a/app/views/shared/_activity_contents.html.haml
+++ b/app/views/shared/_activity_contents.html.haml
@@ -106,7 +106,7 @@
       -# %li.tab
       -#   %span
       -#     周辺情報
-  - if images.nil?
+  - if images.length > 0
     .experience_photo_content
       .experience_photo_title_area
         .experience_photo_title_icon


### PR DESCRIPTION
## 概要
* アクティビティ詳細の`写真一覧ページ`において、写真が投稿されていても『まだ写真は投稿されていません。』と表示されてしまっていたので、ビューファイルを修正。

## 変更点
* `_activity_contents.html.haml`内の写真の有無によって表示を分岐させるif文の条件を修正。

## テスト結果とテスト項目
- [x] 写真投稿されていれば写真一覧が表示され、写真投稿されていなければ表示を分岐されている。

## Issue番号
close #94 