### PR TITLE
ヘッダーのロゴ画像が本番環境でも表示される様に設定

### DIFF
--- a/app/views/shared/_leh_header.html.haml
+++ b/app/views/shared/_leh_header.html.haml
@@ -2,7 +2,7 @@
   .header_wrapper
     .leh_icon
       = link_to root_path, class: 'root_link' do
-        = image_tag 'leh_logo.png', alt: 'アイコン画像', height: '80px', width: '80px', class: 'register_icon'
+        = image_tag asset_path('leh_logo.png'), alt: 'アイコン画像', height: '80px', width: '80px', class: 'register_icon'
     .leh_sign_login
       .sign_login_wrapper
         %ul.sign_login


### PR DESCRIPTION
## 概要
* ヘッダーに使用しているロゴ画像が表示されない様になっているため、コードを修正して表示される様にする。

## 変更点
* `_leh_header.html.haml`内のロゴ画像表示コードの画像指定部分に`asset_path`を使用。

## テスト結果とテスト項目
- [x] `asset_path`を使用しても画像が表示されている。

## Issue番号
close #104