### PR TITLE
ゲストユーザーログイン機能及びその他修正

### DIFF
--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -158,14 +158,10 @@ $regHeight: 881px;
                 font-size: 14px;
                 margin-right: 5px;
               }
-              .testuser_login_form{
-                .testuser_login_button{
-                  font-size: 14px;
-                  color: #008dde;
-                  border-style: none;
-                  background-color: #fff;
-                  cursor: pointer;
-                }
+              .testuser_login_button{
+                font-size: 14px;
+                color: #008dde;
+                text-decoration: none;
               }
             }
             .login_link{

--- a/app/assets/stylesheets/pages/_signinup.scss
+++ b/app/assets/stylesheets/pages/_signinup.scss
@@ -148,17 +148,17 @@ $regHeight: 881px;
                 text-decoration: none;
               }
             }
-            .testuser_sign_in_form{
+            .guestuser_sign_in_form{
               width: 100%;
               margin-top: 20px;
               display: flex;
               justify-content: center;
               align-items: center;
-              .testuser_login_text{
+              .guestuser_login_text{
                 font-size: 14px;
                 margin-right: 5px;
               }
-              .testuser_login_button{
+              .guestuser_login_button{
                 font-size: 14px;
                 color: #008dde;
                 text-decoration: none;

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -11,7 +11,7 @@ class ReviewsController < ApplicationController
   end
 
   def user_index
-    @reviews = Review.includes(:experience).where(experience_id: params[:id]).order('created_at DESC')
+    @reviews = Review.includes(:experience).where(user_id: params[:id]).order('created_at DESC')
     user_is_current_user?(params)
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,7 @@ module Users
   class RegistrationsController < Devise::RegistrationsController
     before_action :configure_sign_up_params, only: %i[create]
     before_action :configure_account_update_params, only: %i[update]
+    before_action :check_guest, only: %i[update]
 
     def new
       @user = User.new
@@ -27,6 +28,12 @@ module Users
     # GET /resource/edit
     def edit
       find_user_show
+    end
+
+    def check_guest
+      if resource.email = 'guest@sample.com'
+        redirect_to request.referer
+      end
     end
 
     # PUT /resource

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,12 @@ module Users
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
 
+    def new_guest
+      user = User.guest
+      sign_in user
+      redirect_root
+    end
+
     # GET /resource/sign_in
     # def new
     #   super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,9 @@ class User < ApplicationRecord
   end
 
   def self.guest
-    find_or_create_by!(email: 'test@test.com') do |user|
+    find_or_create_by!(email: 'guest@sample.com') do |user|
+      user.name = 'ゲストユーザー'
+      user.introduce = 'ゲストユーザーです。'
       user.password = "#{SecureRandom.urlsafe_base64(7)}!!"
       user.password_confirmation = user.password
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,4 +43,11 @@ class User < ApplicationRecord
     end
     { user: user, sns: sns }
   end
+
+  def self.guest
+    find_or_create_by!(email: 'test@test.com') do |user|
+      user.password = "#{SecureRandom.urlsafe_base64(7)}!!"
+      user.password_confirmation = user.password
+    end
+  end
 end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -9,13 +9,10 @@
             .signin_up_form
               / 入力フォーム
               = form_with model: @user, url: user_session_path, local: true, class: 'signin_up_user' do |f|
-                = render "devise/shared/error_messages", resource: @user
                 .signin_up_form_input
                   = f.email_field :email, placeholder: 'メールアドレス', autocomplete: "email", autocorrect: 'off', autocapitalize: 'off', class: 'signin_up_input'
-                  %span{style: 'display:none', class: 'signin_up_error_message'}この項目は必須です
                 .signin_up_form_input
                   = f.password_field :password, placeholder: 'パスワード（8～20文字・半角英数字・記号を2種以上）', maxlength: '20', autocomplete: "current-password", class: 'signin_up_input'
-                  %span{style: 'display:none', class: 'signin_up_error_message'}この項目は必須です
                 - if devise_mapping.rememberable?
                   .remember_me_password
                     %label.remember_me
@@ -36,11 +33,11 @@
                   = link_to image_tag("f_logo_RGB-Blue_58.png", height: '30px', width: '30px'), user_facebook_omniauth_authorize_path, method: :post, class: 'social_login_link'
               / SNSアカウントでログインできる
               = render "devise/shared/links"
-              / テストユーザーとしてログインするためのフォーム
-              .testuser_sign_in_form
-                %span.testuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
-                = link_to 'こちら', users_guest_sign_in_path, method: :post, class: 'testuser_login_button link_hover_not_underline'
-              / テストユーザーとしてログインするためのフォーム
+              / ゲストユーザーとしてログインするためのフォーム
+              .guestuser_sign_in_form
+                %span.guestuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
+                = link_to 'こちら', users_guest_sign_in_path, method: :post, class: 'guestuser_login_button link_hover_not_underline'
+              / ゲストユーザーとしてログインするためのフォーム
       / フッター
       .signin_up_footer
         %ul.signin_up_footer_list

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -39,10 +39,7 @@
               / テストユーザーとしてログインするためのフォーム
               .testuser_sign_in_form
                 %span.testuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
-                = form_with model: @user, url: user_session_path, local: true, class: 'testuser_login_form' do |f|
-                  = f.hidden_field :email, :value => 'test@test.com'
-                  = f.hidden_field :password, :value => 'testtest1!!'
-                  = f.submit "こちら", class: 'testuser_login_button link_hover_not_underline'
+                = link_to 'こちら', users_guest_sign_in_path, method: :post, class: 'testuser_login_button link_hover_not_underline'
               / テストユーザーとしてログインするためのフォーム
       / フッター
       .signin_up_footer

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -41,10 +41,7 @@
               / テストユーザーとしてログインするためのフォーム
               .testuser_sign_in_form
                 %span.testuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
-                = form_with model: @user, url: user_session_path, local: true, class: 'testuser_login_form' do |f|
-                  = f.hidden_field :email, :value => 'test@test.com', id: 'test_user_email'
-                  = f.hidden_field :password, :value => 'testtest1!!', id: 'test_user_password'
-                  = f.submit "こちら", class: 'testuser_login_button link_hover_not_underline'
+                = link_to 'こちら', users_guest_sign_in_path, method: :post, class: 'testuser_login_button link_hover_not_underline'
               / テストユーザーとしてログインするためのフォーム
       / フッター
       .signin_up_footer

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -33,16 +33,16 @@
                 #facebook_login
                   = link_to image_tag("f_logo_RGB-Blue_58.png", height: '30px', width: '30px'), user_facebook_omniauth_authorize_path, method: :post, class: 'social_login_link'
               / SNSアカウントでログインできる
-            %p.register_policy
-              会員登録に伴い、
-              %a{href: '#', class: 'register_policy_link link_hover_not_underline'}プライバシーポリシー
-              に同意したものとみなされます。
-              = render "devise/shared/links"
-              / テストユーザーとしてログインするためのフォーム
-              .testuser_sign_in_form
-                %span.testuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
-                = link_to 'こちら', users_guest_sign_in_path, method: :post, class: 'testuser_login_button link_hover_not_underline'
-              / テストユーザーとしてログインするためのフォーム
+            -# %p.register_policy
+            -#   会員登録に伴い、
+            -#   %a{href: '#', class: 'register_policy_link link_hover_not_underline'}プライバシーポリシー
+            -#   に同意したものとみなされます。
+            = render "devise/shared/links"
+            / ゲストユーザーとしてログインするためのフォーム
+            .guestuser_sign_in_form
+              %span.guestuser_login_text ※アカウント登録せず、ユーザー機能を試したい方は
+              = link_to 'こちら', users_guest_sign_in_path, method: :post, class: 'guestuser_login_button link_hover_not_underline'
+            / ゲストユーザーとしてログインするためのフォーム
       / フッター
       .signin_up_footer
         %ul.signin_up_footer_list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@
 
 Rails.application.routes.draw do
   root to: 'tops#index'
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#new_guest'
+  end
   devise_for :users,
              controllers: {
                omniauth_callbacks: 'users/omniauth_callbacks',


### PR DESCRIPTION
## 概要
* ゲストユーザーログイン時にゲストユーザーの情報が変更できてしま雨状態だったので、修正する。
* 投稿した口コミがマイページ内で表示されていなかったので、コードを修正する。

## 変更点
* `マイページ`内`口コミ投稿表示ページ`で、口コミ投稿していても表示がされていなかった為、`reviews#user_index`のコードを修正。
* `Userモデル`内に、メールアドレスでゲストユーザーを検索し、存在しなければ新たにゲストユーザーを作成するメソッドを定義。
* `sessionsコントローラー`内にゲストユーザーとしてログインする為の`new_guestメソッド`を定義。
* `新規登録・ログイン画面`のゲストユーザーログインへのリンクを`sessions#new_guest`に修正。

## テスト結果とテスト項目
- [x] `ゲストユーザーログインボタン`を選択すると、ゲストユーザーとしてログインできる。
- [x] `マイページ`の`口コミ一覧ページ`にアクセスすると、投稿した口コミの一覧が表示される。

## Issue番号
close #116 