### PR TITLE
他人のユーザーページにアクセスした際に、ホーム画面にリダイレクトされる様に修正

### DIFF
--- a/app/javascript/routes/router.js
+++ b/app/javascript/routes/router.js
@@ -59,15 +59,14 @@ export default new Router({
       beforeEnter: async (to, from, next) => {
         const userId = Number(store.getters.userData.id);
         const userPageId = Number(to.params.id);
+        const isUserPage = /\/users\/\d/.test(to.path);
 
-        if (/\/users\/\d/.test(to.path)) {
+        if (isUserPage && userId === userPageId) {
           await store.dispatch('toUsersPage', to.params.id);
-        }
-        if (userId === userPageId) {
           return next();
-        } else {
-          return next('/');
         }
+
+        return next('/');
       },
     },
     // アクティビティ詳細ページ


### PR DESCRIPTION
## 概要
* 他人のユーザーページにアクセスした際に、ホーム画面にリダイレクトされていなかったため、リダイレクトされる様に修正。

## 変更点
* `マイページ`アクセス時に、自身のページか判定を行い、他人のページであればホーム画面にリダイレクトされる様`router.js`内の処理を修正。

## テスト結果とテスト項目
- [x] 他人の`マイページ`にアクセスすると、ホーム画面にリダイレクトされる。

## Issue番号
close #139 