### PR TITLE
AdSense広告導入

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
     %meta{name: "viewport", content:"width=device-width, initial-scale=1.0"}/
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title LetsEnjoyHawaii
+    %script{:async => "", "data-ad-client" => "ca-pub-6560431001903272", :src => "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"}
     = csrf_meta_tags
     = csp_meta_tag
     = favicon_link_tag 'favicon.ico'


### PR DESCRIPTION
## 概要
* Google広告の`AdSense`の広告用scriptタグをheadタグ内に挿入。

## 変更点
* `application.html.haml`の`headタグ`内に`AdSense`用のscriptタグを挿入。

## Issue番号
close #148 